### PR TITLE
레시피 작성, 상세 페이지 틀 구현 및 프론트 연동

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/domain/recipe/controller/RecipeController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/recipe/controller/RecipeController.java
@@ -1,9 +1,50 @@
+//package com.sloweat.domain.recipe.controller;
+//
+//import com.sloweat.domain.recipe.dto.RecipeRequestDto;
+//import com.sloweat.domain.recipe.dto.RecipeResponseDto;
+//import com.sloweat.domain.recipe.service.RecipeService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//@RestController
+//@RequestMapping("/api/recipes")
+//@RequiredArgsConstructor
+//public class RecipeController {
+//
+//    private final RecipeService recipeService;
+//
+//    /**
+//     * 게시글 작성
+//     */
+//    @PostMapping
+//    public ResponseEntity<String> createRecipe(@RequestBody RecipeRequestDto recipeDto) {
+//        recipeService.saveRecipe(recipeDto);
+//        return ResponseEntity.status(HttpStatus.CREATED).body("게시글이 성공적으로 작성되었습니다!");
+//    }
+//
+//    /**
+//     * 게시글 상세 조회
+//     */
+//    @GetMapping("/{id}")
+//    public ResponseEntity<RecipeResponseDto> getRecipeDetail(@PathVariable Integer id) {
+//        RecipeResponseDto responseDto = recipeService.getRecipeDetail(id);
+//        return ResponseEntity.ok(responseDto);
+//    }
+//}
+
 package com.sloweat.domain.recipe.controller;
 
+import com.sloweat.domain.recipe.dto.RecipeRequestDto;
+import com.sloweat.domain.recipe.dto.RecipeResponseDto;
 import com.sloweat.domain.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/recipes")
@@ -11,4 +52,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecipeController {
 
     private final RecipeService recipeService;
+
+    /**
+     * 게시글 작성
+     */
+    @PostMapping
+    public ResponseEntity<Map<String, Integer>> createRecipe(@RequestBody RecipeRequestDto recipeDto) {
+        int savedId = recipeService.saveRecipe(recipeDto); // 게시글 저장하고 반환된 ID
+        Map<String, Integer> responseBody = new HashMap<>();
+        responseBody.put("id", savedId); // JSON 구조로 응답: { "id": 6 }
+        return ResponseEntity.ok(responseBody);
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<RecipeResponseDto> getRecipeDetail(@PathVariable Integer id) {
+        RecipeResponseDto responseDto = recipeService.getRecipeDetail(id);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeRequest.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeRequest.java
@@ -1,4 +1,0 @@
-package com.sloweat.domain.recipe.dto;
-
-public class RecipeRequest {
-}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeRequestDto.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeRequestDto.java
@@ -1,0 +1,15 @@
+package com.sloweat.domain.recipe.dto;
+
+import lombok.Data;
+
+@Data
+public class RecipeRequestDto {
+
+    private int userId;             // 작성자 ID
+    private String title;           // 제목
+    private String content;         // 내용
+    private int cookingTime;        // 요리 시간
+    private boolean isSubscribed;   // 유료 여부
+
+    // 추후 확장 가능: 이미지 URL, 태그 등
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeResponse.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeResponse.java
@@ -1,4 +1,0 @@
-package com.sloweat.domain.recipe.dto;
-
-public class RecipeResponse {
-}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeResponseDto.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/recipe/dto/RecipeResponseDto.java
@@ -1,0 +1,25 @@
+package com.sloweat.domain.recipe.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class RecipeResponseDto {
+
+    private Integer recipeId;       // 게시글 ID
+    private String title;           // 제목
+    private String content;         // 본문
+    private int cookingTime;        // 조리 시간 (분)
+    private boolean isSubscribed;   // 프리미엄 여부
+    private LocalDateTime createdAt;// 작성일자
+    private int views;              // 조회수
+    private int likes;              // 좋아요 수
+
+    private String chefName;        // 셰프 이름
+    private String username;        // 셰프 아이디 (ex. @chefkim)
+
+    private List<String> tags;      // 태그 목록
+    private List<String> photoUrls; // 업로드된 이미지들
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/recipe/service/RecipeService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/recipe/service/RecipeService.java
@@ -1,13 +1,141 @@
+//package com.sloweat.domain.recipe.service;
+//
+//import com.sloweat.domain.recipe.dto.RecipeResponseDto;
+//import com.sloweat.domain.recipe.dto.RecipeRequestDto;
+//import com.sloweat.domain.recipe.entity.Recipe;
+//import com.sloweat.domain.recipe.repository.RecipeRepository;
+//import com.sloweat.domain.user.entity.User;
+//import com.sloweat.domain.user.repository.UserRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//
+//import java.time.LocalDateTime;
+//import java.util.List;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class RecipeService {
+//
+//    private final RecipeRepository recipeRepository;
+//    private final UserRepository userRepository;
+//
+//    /**
+//     * 새 레시피 저장
+//     */
+//    public void saveRecipe(RecipeRequestDto dto) {
+//        Recipe recipe = new Recipe();
+//
+//        recipe.setTitle(dto.getTitle());
+//        recipe.setContent(dto.getContent());
+//        recipe.setCookingTime(dto.getCookingTime());
+//        recipe.setIsSubscribed(dto.isSubscribed());
+//        recipe.setCreatedAt(LocalDateTime.now());
+//        recipe.setUpdatedAt(LocalDateTime.now());
+//
+//        User user = userRepository.findById(dto.getUserId()).orElse(null);
+//        recipe.setUser(user);
+//
+//        recipeRepository.save(recipe);
+//    }
+//
+//    /**
+//     * 게시글 상세 조회
+//     */
+//    public RecipeResponseDto getRecipeDetail(Integer id) {
+//        Recipe recipe = recipeRepository.findById(id).orElse(null);
+//        if (recipe == null) return null;
+//
+//        RecipeResponseDto dto = new RecipeResponseDto();
+//        dto.setRecipeId(recipe.getRecipeId());
+//        dto.setTitle(recipe.getTitle());
+//        dto.setContent(recipe.getContent());
+//        dto.setCookingTime(recipe.getCookingTime());
+//        dto.setSubscribed(recipe.getIsSubscribed());
+//        dto.setCreatedAt(recipe.getCreatedAt());
+//        dto.setViews(recipe.getViews());
+//        dto.setLikes(recipe.getLikes());
+//
+////        if (recipe.getUser() != null) {
+////            dto.setChefName(recipe.getUser().getName());
+////            dto.setUsername("@" + recipe.getUser().getUsername());
+////        }
+//
+//        // 예시: 태그나 사진이 있다면 여기에 추가할 수 있어
+//        dto.setTags(List.of("크림파스타", "홈쿠킹", "이탈리안", "간단요리"));
+//        dto.setPhotoUrls(List.of("https://image.server.com/photo1.jpg"));
+//
+//        return dto;
+//    }
+//}
+
 package com.sloweat.domain.recipe.service;
 
+import com.sloweat.domain.recipe.dto.RecipeResponseDto;
+import com.sloweat.domain.recipe.dto.RecipeRequestDto;
+import com.sloweat.domain.recipe.entity.Recipe;
 import com.sloweat.domain.recipe.repository.RecipeRepository;
+import com.sloweat.domain.user.entity.User;
+import com.sloweat.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RecipeService {
 
     private final RecipeRepository recipeRepository;
+    private final UserRepository userRepository;
 
+    /**
+     * 새 레시피 저장 (📌 수정된 부분: int 반환)
+     */
+    public int saveRecipe(RecipeRequestDto dto) {
+        Recipe recipe = new Recipe();
+
+        recipe.setTitle(dto.getTitle());
+        recipe.setContent(dto.getContent());
+        recipe.setCookingTime(dto.getCookingTime());
+        recipe.setIsSubscribed(dto.isSubscribed());
+        recipe.setCreatedAt(LocalDateTime.now());
+        recipe.setUpdatedAt(LocalDateTime.now());
+
+        User user = userRepository.findById(dto.getUserId()).orElse(null);
+        recipe.setUser(user);
+
+        Recipe savedRecipe = recipeRepository.save(recipe); // 저장 후 객체 반환
+        return savedRecipe.getRecipeId(); // 🟢 저장된 레시피의 ID 반환
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    public RecipeResponseDto getRecipeDetail(Integer id) {
+        Recipe recipe = recipeRepository.findById(id).orElse(null);
+        if (recipe == null) return null;
+
+        RecipeResponseDto dto = new RecipeResponseDto();
+        dto.setRecipeId(recipe.getRecipeId());
+        dto.setTitle(recipe.getTitle());
+        dto.setContent(recipe.getContent());
+        dto.setCookingTime(recipe.getCookingTime());
+        dto.setSubscribed(recipe.getIsSubscribed());
+        dto.setCreatedAt(recipe.getCreatedAt());
+        dto.setViews(recipe.getViews());
+        dto.setLikes(recipe.getLikes());
+
+        // 프로필 정보 추가하고 싶다면 아래 주석 해제
+        // if (recipe.getUser() != null) {
+        //     dto.setChefName(recipe.getUser().getName());
+        //     dto.setUsername("@" + recipe.getUser().getUsername());
+        // }
+
+        // 예시: 태그나 사진이 있다면 여기에 추가할 수 있음
+        dto.setTags(List.of("크림파스타", "홈쿠킹", "이탈리안", "간단요리"));
+        dto.setPhotoUrls(List.of("https://image.server.com/photo1.jpg"));
+
+        return dto;
+    }
 }

--- a/backend/sloweat/src/main/resources/application.yml
+++ b/backend/sloweat/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     name: sloweat
   datasource:
     url: jdbc:mysql://localhost:3306/sloweat?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: mydb
+    username: root
     password: admin1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.3",
@@ -4543,6 +4544,33 @@
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -12614,6 +12642,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",

--- a/frontend/src/components/user/RecipeCard.jsx
+++ b/frontend/src/components/user/RecipeCard.jsx
@@ -1,17 +1,201 @@
+// import { useState } from 'react';
+// import { useNavigate } from 'react-router-dom';
+// import '../../styles/user/RecipeCard.css';
+//
+// function Recipe({ isDetail = false, isMyPost = false }) {
+//   const [liked, setLiked] = useState(false);
+//   const [likeCount, setLikeCount] = useState(100);
+//   const [bookmarked, setBookmarked] = useState(false);
+//   const [isFollowing, setIsFollowing] = useState(false);
+//
+//   const navigate = useNavigate();
+//
+//   const handleCardClick = () => {
+//     navigate('/postdetail');
+//   };
+//
+//   const handleLike = (e) => {
+//     e.stopPropagation();
+//     setLiked((prev) => {
+//       const newLiked = !prev;
+//       setLikeCount((count) => count + (newLiked ? 1 : -1));
+//       return newLiked;
+//     });
+//   };
+//
+//   const handleBookmark = (e) => {
+//     e.stopPropagation();
+//     setBookmarked((prev) => !prev);
+//   };
+//
+//   const handleReport = (e) => {
+//     e.stopPropagation();
+//     if (window.confirm('신고하시겠습니까?')) {
+//       alert('신고가 접수되었습니다.');
+//     }
+//   };
+//
+//   const handleFollowToggle = (e) => {
+//     e.stopPropagation();
+//     setIsFollowing((prev) => !prev);
+//   };
+//
+//   const handleProfileClick = (e) => {
+//     e.stopPropagation();
+//     navigate('/userpage');
+//   };
+//
+//   const handleEdit = () => {
+//     alert('수정 페이지로 이동합니다.');
+//     navigate('/postform');
+//   };
+//
+//   const handleDelete = () => {
+//     if (window.confirm('삭제하시겠습니까?')) {
+//       alert('삭제되었습니다.');
+//     }
+//   };
+//
+//   return (
+//     <div className="recipe-card-link" onClick={handleCardClick}>
+//       <div className="recipe-card-box">
+//         <div className="recipe-card-view">
+//           <div className="recipe-card-content">
+//
+//             {/* 프로필 헤더 */}
+//             <div className="recipe-card-profile-header">
+//               <img
+//                 onClick={handleProfileClick}
+//                 className="recipe-card-profile-image"
+//                 src="https://c.animaapp.com/RwKPZPrR/img/---@2x.png"
+//                 alt="Chef Kim's profile"
+//               />
+//               <div className="recipe-card-profile-info">
+//                 <div className="recipe-card-chef-name-row">
+//                   <h1 className="recipe-card-chef-name">요리왕김셰프</h1>
+//                   {isDetail && (
+//                     <button
+//                       className={`follower-card-button ${isFollowing ? 'following' : ''}`}
+//                       onClick={handleFollowToggle}
+//                     >
+//                       {isFollowing ? '팔로잉' : '팔로우'}
+//                     </button>
+//                   )}
+//                 </div>
+//                 <div className="recipe-card-meta-info">
+//                   <span className="recipe-card-username">@chefkim</span>
+//                 </div>
+//               </div>
+//
+//               {/* 더보기 (hover 시 드롭다운) */}
+//               <div className="recipe-card-report">
+//                 <img
+//                   className="comment-card-more-icon"
+//                   src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM2Yjc2N2MiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0ibHVjaWRlIGx1Y2lkZS1lbGxpcHNpcy1pY29uIGx1Y2lkZS1lbGxpcHNpcyI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMSIvPjxjaXJjbGUgY3g9IjE5IiBjeT0iMTIiIHI9IjEiLz48Y2lyY2xlIGN4PSI1IiBjeT0iMTIiIHI9IjEiLz48L3N2Zz4="
+//                   alt="더 보기 아이콘"
+//                 />
+//                 <div className="recipe-card-dropdown">
+//                   {isMyPost ? (
+//                     <>
+//                       <button className="recipe-card-dropdown-button" onClick={handleEdit}>수정</button>
+//                       <button className="recipe-card-dropdown-button" onClick={handleDelete}>삭제</button>
+//                     </>
+//                   ) : (
+//                     <button className="recipe-card-dropdown-button" style={{ color: '#ef4444' }}  onClick={handleReport}>신고하기</button>
+//                   )}
+//                 </div>
+//               </div>
+//             </div>
+//
+//             {/* 본문 내용 */}
+//             <p className="recipe-card-description">
+//               오늘 만든 크림 파스타 레시피 공유합니다! 집에서도 레스토랑 수준의 맛을 낼 수 있어요 🍝✨
+//               <br /><br />
+//               <strong>재료:</strong> 파스타면 200g, 생크림 200ml, 마늘 3쪽, 베이컨 100g, 파마산 치즈
+//               <br /><br />
+//               <strong>조리법:</strong><br />
+//               1. 베이컨을 바삭하게 볶아주세요<br />
+//               2. 마늘을 넣고 향을 내주세요<br />
+//               3. 생크림을 넣고 끓여주세요<br />
+//               4. 삶은 파스타와 치즈를 넣고 섞어주세요
+//             </p>
+//
+//             {/* 해시태그 */}
+//             <ul className="recipe-card-hashtags">
+//               <li className="recipe-card-hashtag">#크림파스타</li>
+//               <li className="recipe-card-hashtag">#홈쿠킹</li>
+//               <li className="recipe-card-hashtag">#이탈리안</li>
+//               <li className="recipe-card-hashtag">#간단요리</li>
+//             </ul>
+//
+//             {/* 액션 바 */}
+//             <div className="recipe-card-action-row">
+//               <div className="recipe-card-left-actions">
+//                 <div className="recipe-card-cooking-time">
+//                   <img className="clock-icon" src="https://c.animaapp.com/RwKPZPrR/img/frame-1.svg" alt="Clock" />
+//                   <span className="time">30분</span>
+//                 </div>
+//                 <button
+//                   className={`recipe-card-likes ${liked ? 'active' : ''}`}
+//                   onClick={handleLike}
+//                 >
+//                   <svg className="heart-icon" width="16" height="16" viewBox="0 0 18 18" fill="none">
+//                     <path
+//                       d="M8.78 15.43C6.69 13.55 5.06 12.08 3.94 10.73C2.83 9.39 2.25 8.16 2.25 6.84C2.25 4.71 3.94 3.09 6.19 3.09C7.24 3.09 8.25 3.53 9 4.23C9.75 3.53 10.76 3.09 11.81 3.09C14.06 3.09 15.75 4.71 15.75 6.84C15.75 8.16 15.16 9.39 14.06 10.73C12.94 12.08 11.31 13.55 9.22 15.43L9 15.63L8.78 15.43Z"
+//                       stroke="#10B981"
+//                       strokeWidth="1.5"
+//                       fill={liked ? "#10B981" : "none"}
+//                     />
+//                   </svg>
+//                   <span className="recipe-card-like-count">{likeCount}</span>
+//                 </button>
+//               </div>
+//
+//               <div className="recipe-card-bottom-right">
+//                 <div className="recipe-card-view-count">
+//                   <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM2YjcyODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0ibHVjaWRlIGx1Y2lkZS1jaGFydC1uby1heGVzLWNvbHVtbi1pY29uIGx1Y2lkZS1jaGFydC1uby1heGVzLWNvbHVtbiI+PGxpbmUgeDE9IjE4IiB4Mj0iMTgiIHkxPSIyMCIgeTI9IjEwIi8+PGxpbmUgeDE9IjEyIiB4Mj0iMTIiIHkxPSIyMCIgeTI9IjQiLz48bGluZSB4MT0iNiIgeDI9IjYiIHkxPSIyMCIgeTI9IjE0Ii8+PC9zdmc+"
+//                        alt="조회수" />
+//                   <p>242</p>
+//                 </div>
+//                 <button
+//                   className={`recipe-card-bookmark-button ${bookmarked ? 'active' : ''}`}
+//                   onClick={handleBookmark}
+//                 >
+//                   <svg width="16" height="20" viewBox="0 0 16 20" fill="none">
+//                     <path
+//                       d="M1.5 0.5H14.5C14.78 0.5 15 0.72 15 1V19C15 19.18 14.91 19.35 14.75 19.42C14.6 19.5 14.41 19.48 14.28 19.36L8 14.06L1.72 19.36C1.59 19.48 1.4 19.5 1.25 19.42C1.09 19.35 1 19.18 1 19V1C1 0.72 1.22 0.5 1.5 0.5Z"
+//                       stroke="#6B7280"
+//                       strokeWidth="1.5"
+//                       fill={bookmarked ? "#10B981" : "none"}
+//                     />
+//                   </svg>
+//                 </button>
+//               </div>
+//             </div>
+//
+//           </div>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+//
+// export default Recipe;
+
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../../styles/user/RecipeCard.css';
 
-function Recipe({ isDetail = false, isMyPost = false }) {
+function Recipe({ isDetail = false, isMyPost = false, data }) {
   const [liked, setLiked] = useState(false);
-  const [likeCount, setLikeCount] = useState(100);
+  const [likeCount, setLikeCount] = useState(data?.likeCount || 0);
   const [bookmarked, setBookmarked] = useState(false);
   const [isFollowing, setIsFollowing] = useState(false);
 
   const navigate = useNavigate();
 
   const handleCardClick = () => {
-    navigate('/postdetail');
+    navigate(`/postdetail/${data?.id}`);
   };
 
   const handleLike = (e) => {
@@ -47,7 +231,7 @@ function Recipe({ isDetail = false, isMyPost = false }) {
 
   const handleEdit = () => {
     alert('수정 페이지로 이동합니다.');
-    navigate('/postform');
+    navigate(`/postform/${data?.id}`);
   };
 
   const handleDelete = () => {
@@ -61,18 +245,17 @@ function Recipe({ isDetail = false, isMyPost = false }) {
       <div className="recipe-card-box">
         <div className="recipe-card-view">
           <div className="recipe-card-content">
-
             {/* 프로필 헤더 */}
             <div className="recipe-card-profile-header">
               <img
                 onClick={handleProfileClick}
                 className="recipe-card-profile-image"
-                src="https://c.animaapp.com/RwKPZPrR/img/---@2x.png"
-                alt="Chef Kim's profile"
+                src={data?.chefProfileUrl || 'https://c.animaapp.com/RwKPZPrR/img/---@2x.png'}
+                alt="프로필 이미지"
               />
               <div className="recipe-card-profile-info">
                 <div className="recipe-card-chef-name-row">
-                  <h1 className="recipe-card-chef-name">요리왕김셰프</h1>
+                  <h1 className="recipe-card-chef-name">{data?.chefName || '익명 셰프'}</h1>
                   {isDetail && (
                     <button
                       className={`follower-card-button ${isFollowing ? 'following' : ''}`}
@@ -83,16 +266,16 @@ function Recipe({ isDetail = false, isMyPost = false }) {
                   )}
                 </div>
                 <div className="recipe-card-meta-info">
-                  <span className="recipe-card-username">@chefkim</span>
+                  <span className="recipe-card-username">@{data?.username || 'unknown'}</span>
                 </div>
               </div>
 
-              {/* 더보기 (hover 시 드롭다운) */}
+              {/* 더보기 드롭다운 */}
               <div className="recipe-card-report">
                 <img
                   className="comment-card-more-icon"
-                  src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM2Yjc2N2MiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0ibHVjaWRlIGx1Y2lkZS1lbGxpcHNpcy1pY29uIGx1Y2lkZS1lbGxpcHNpcyI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMSIvPjxjaXJjbGUgY3g9IjE5IiBjeT0iMTIiIHI9IjEiLz48Y2lyY2xlIGN4PSI1IiBjeT0iMTIiIHI9IjEiLz48L3N2Zz4="
-                  alt="더 보기 아이콘"
+                  src="..."
+                  alt="더보기"
                 />
                 <div className="recipe-card-dropdown">
                   {isMyPost ? (
@@ -101,7 +284,7 @@ function Recipe({ isDetail = false, isMyPost = false }) {
                       <button className="recipe-card-dropdown-button" onClick={handleDelete}>삭제</button>
                     </>
                   ) : (
-                    <button className="recipe-card-dropdown-button" style={{ color: '#ef4444' }}  onClick={handleReport}>신고하기</button>
+                    <button className="recipe-card-dropdown-button" style={{ color: '#ef4444' }} onClick={handleReport}>신고하기</button>
                   )}
                 </div>
               </div>
@@ -109,66 +292,45 @@ function Recipe({ isDetail = false, isMyPost = false }) {
 
             {/* 본문 내용 */}
             <p className="recipe-card-description">
-              오늘 만든 크림 파스타 레시피 공유합니다! 집에서도 레스토랑 수준의 맛을 낼 수 있어요 🍝✨ 
-              <br /><br />
-              <strong>재료:</strong> 파스타면 200g, 생크림 200ml, 마늘 3쪽, 베이컨 100g, 파마산 치즈
-              <br /><br />
-              <strong>조리법:</strong><br />
-              1. 베이컨을 바삭하게 볶아주세요<br />
-              2. 마늘을 넣고 향을 내주세요<br />
-              3. 생크림을 넣고 끓여주세요<br />
-              4. 삶은 파스타와 치즈를 넣고 섞어주세요
+              {data?.content
+                ? data.content.split('\n').map((line, idx) => (
+                    <span key={idx}>{line}<br /></span>
+                  ))
+                : '레시피 내용이 없습니다.'
+              }
             </p>
 
             {/* 해시태그 */}
             <ul className="recipe-card-hashtags">
-              <li className="recipe-card-hashtag">#크림파스타</li>
-              <li className="recipe-card-hashtag">#홈쿠킹</li>
-              <li className="recipe-card-hashtag">#이탈리안</li>
-              <li className="recipe-card-hashtag">#간단요리</li>
+              {data?.tags?.map((tag, idx) => (
+                <li key={idx} className="recipe-card-hashtag">#{tag}</li>
+              ))}
             </ul>
 
             {/* 액션 바 */}
             <div className="recipe-card-action-row">
               <div className="recipe-card-left-actions">
                 <div className="recipe-card-cooking-time">
-                  <img className="clock-icon" src="https://c.animaapp.com/RwKPZPrR/img/frame-1.svg" alt="Clock" />
-                  <span className="time">30분</span>
+                  <img className="clock-icon" src="..." alt="조리시간" />
+                  <span className="time">{data?.cookingTime}분</span>
                 </div>
                 <button
                   className={`recipe-card-likes ${liked ? 'active' : ''}`}
                   onClick={handleLike}
                 >
-                  <svg className="heart-icon" width="16" height="16" viewBox="0 0 18 18" fill="none">
-                    <path
-                      d="M8.78 15.43C6.69 13.55 5.06 12.08 3.94 10.73C2.83 9.39 2.25 8.16 2.25 6.84C2.25 4.71 3.94 3.09 6.19 3.09C7.24 3.09 8.25 3.53 9 4.23C9.75 3.53 10.76 3.09 11.81 3.09C14.06 3.09 15.75 4.71 15.75 6.84C15.75 8.16 15.16 9.39 14.06 10.73C12.94 12.08 11.31 13.55 9.22 15.43L9 15.63L8.78 15.43Z"
-                      stroke="#10B981"
-                      strokeWidth="1.5"
-                      fill={liked ? "#10B981" : "none"}
-                    />
-                  </svg>
-                  <span className="recipe-card-like-count">{likeCount}</span>
+                  ❤️ <span className="recipe-card-like-count">{likeCount}</span>
                 </button>
               </div>
 
               <div className="recipe-card-bottom-right">
                 <div className="recipe-card-view-count">
-                  <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM2YjcyODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0ibHVjaWRlIGx1Y2lkZS1jaGFydC1uby1heGVzLWNvbHVtbi1pY29uIGx1Y2lkZS1jaGFydC1uby1heGVzLWNvbHVtbiI+PGxpbmUgeDE9IjE4IiB4Mj0iMTgiIHkxPSIyMCIgeTI9IjEwIi8+PGxpbmUgeDE9IjEyIiB4Mj0iMTIiIHkxPSIyMCIgeTI9IjQiLz48bGluZSB4MT0iNiIgeDI9IjYiIHkxPSIyMCIgeTI9IjE0Ii8+PC9zdmc+" 
-                       alt="조회수" />
-                  <p>242</p>
+                  👁 <p>{data?.viewCount || 0}</p>
                 </div>
                 <button
                   className={`recipe-card-bookmark-button ${bookmarked ? 'active' : ''}`}
                   onClick={handleBookmark}
                 >
-                  <svg width="16" height="20" viewBox="0 0 16 20" fill="none">
-                    <path
-                      d="M1.5 0.5H14.5C14.78 0.5 15 0.72 15 1V19C15 19.18 14.91 19.35 14.75 19.42C14.6 19.5 14.41 19.48 14.28 19.36L8 14.06L1.72 19.36C1.59 19.48 1.4 19.5 1.25 19.42C1.09 19.35 1 19.18 1 19V1C1 0.72 1.22 0.5 1.5 0.5Z"
-                      stroke="#6B7280"
-                      strokeWidth="1.5"
-                      fill={bookmarked ? "#10B981" : "none"}
-                    />
-                  </svg>
+                  📌
                 </button>
               </div>
             </div>

--- a/frontend/src/components/user/RecipeForm.jsx
+++ b/frontend/src/components/user/RecipeForm.jsx
@@ -1,8 +1,12 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import '../../styles/user/RecipeForm.css';
 import '../../styles/user/Filter.css';
 
 const RecipeForm = () => {
+  const navigate = useNavigate();
+
   const [formData, setFormData] = useState({
     title: '크림 파스타 레시피',
     content: '1. 마늘과 양파를 볶는다.\n2. 생크림과 우유를 넣고 끓인다.\n3. 삶은 파스타를 넣고 섞는다.',
@@ -19,11 +23,7 @@ const RecipeForm = () => {
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;
-    if (type === 'checkbox') {
-      setFormData({ ...formData, [name]: checked });
-    } else {
-      setFormData({ ...formData, [name]: value });
-    }
+    setFormData({ ...formData, [name]: type === 'checkbox' ? checked : value });
   };
 
   const handleFileChange = (e) => {
@@ -43,9 +43,35 @@ const RecipeForm = () => {
     }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log('제출된 폼:', formData);
+
+    const requestData = {
+      userId: 1,
+      title: formData.title,
+      content: formData.content,
+      cookingTime: parseInt(formData.duration),
+      isSubscribed: formData.isPremium
+    };
+
+    try {
+      const response = await axios.post('http://localhost:8080/api/recipes', requestData, {
+        headers: {
+          'Cache-Control': 'no-cache'
+        }
+      });
+      console.log('작성 성공 응답:', response.data);
+
+      console.log('작성 성공:', response.data);
+      alert('글이 성공적으로 등록되었습니다!');
+
+      // ✅ 작성된 게시글 ID 기반으로 상세 페이지 이동
+      const newRecipeId = response.data.id;
+      navigate(`/postdetail/${newRecipeId}`);
+    } catch (error) {
+      console.error('작성 실패:', error);
+      alert('작성 중 오류가 발생했습니다.');
+    }
   };
 
   return (

--- a/frontend/src/pages/user/PostDetail.jsx
+++ b/frontend/src/pages/user/PostDetail.jsx
@@ -1,23 +1,103 @@
+// import { useEffect, useState } from 'react';
+// import { useParams } from 'react-router-dom';
+// import axios from 'axios';
+//
+// import '../../layouts/user/MainLayout.css';
+// import Recipe from "../../components/user/RecipeCard";
+// import CommentSection from '../../components/user/CommentSection';
+//
+// export default function PostDetail() {
+//   const { id } = useParams();             // URL에서 글 ID 추출
+//   const [recipeData, setRecipeData] = useState(null);  // 상세 데이터 상태 저장
+//   const [loading, setLoading] = useState(true);         // 로딩 상태
+//
+//   useEffect(() => {
+//     axios.get(`http://localhost:8080/api/recipes/${id}`)
+//       .then(res => {
+//         setRecipeData(res.data);
+//         setLoading(false);
+//       })
+//       .catch(err => {
+//         console.error('상세 조회 실패:', err);
+//         setLoading(false);
+//       });
+//   }, [id]);
+//
+//   if (loading) {
+//     return <div className="main-layout-content">로딩 중...</div>;
+//   }
+//
+//   if (!recipeData) {
+//     return <div className="main-layout-content">데이터를 불러오지 못했습니다.</div>;
+//   }
+//
+//   return (
+//     <div className="main-layout-content">
+//       {/* Header */}
+//       <div className="postDetail-header">
+//         <h1 className="tap-title">게시글</h1>
+//         <div style={{ width: '663px' }}></div>
+//       </div>
+//
+//       {/* 게시글 상세 */}
+//       <div>
+//         <Recipe isDetail={true} data={recipeData} />
+//       </div>
+//
+//       {/* 댓글 섹션 */}
+//       <CommentSection recipeId={id} />
+//     </div>
+//   );
+// }
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+
 import '../../layouts/user/MainLayout.css';
 import Recipe from "../../components/user/RecipeCard";
 import CommentSection from '../../components/user/CommentSection';
 
 export default function PostDetail() {
+  const { id } = useParams();                     // URL에서 글 ID 추출
+  const [recipeData, setRecipeData] = useState(null);  // 서버에서 받은 상세 데이터
+  const [loading, setLoading] = useState(true);         // 로딩 상태
+
+  useEffect(() => {
+    axios.get(`http://localhost:8080/api/recipes/${id}`) // 백엔드 요청
+      .then(res => {
+        setRecipeData(res.data);
+        setLoading(false);
+      })
+      .catch(err => {
+        console.error('상세 조회 실패:', err);
+        setLoading(false);
+      });
+  }, [id]);
+
+  if (loading) {
+    return <div className="main-layout-content">로딩 중...</div>;
+  }
+
+  if (!recipeData) {
+    return <div className="main-layout-content">데이터를 불러오지 못했습니다.</div>;
+  }
+
   return (
     <div className="main-layout-content">
-      {/* Header */}
+      {/* 상단 타이틀 */}
       <div className="postDetail-header">
         <h1 className="tap-title">게시글</h1>
         <div style={{ width: '663px' }}></div>
       </div>
 
-      {/* 게시글 상세 */}
+      {/* 상세 카드 */}
       <div>
-        <Recipe isDetail={true}/>
+        <Recipe isDetail={true} data={recipeData} />
       </div>
 
-      {/* 댓글 섹션 */}
-      <CommentSection />
-    </div> // ← return 블록 닫기
+      {/* 댓글 */}
+      <CommentSection recipeId={id} />
+    </div>
   );
 }

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -33,7 +33,7 @@ const AppRouter = () => (
         <Route path="/" element={<Home />} />
         <Route path="/search" element={<Search />} />
         <Route path="/membership" element={<Membership />} />
-        <Route path="/postdetail" element={<PostDetail />} />
+        <Route path="/postdetail/:id" element={<PostDetail />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/userpage" element={<UserPage />} />
         <Route path="/postform" element={<PostForm />} />

--- a/frontend/src/routes/UserRouter.jsx
+++ b/frontend/src/routes/UserRouter.jsx
@@ -1,0 +1,30 @@
+// import { BrowserRouter, Routes, Route } from 'react-router-dom';
+// import ScrollToTop from '../utils/ScrollToTop';
+// import MainLayout from '../layouts/user/MainLayout';
+// import Home from '../pages/user/Home';
+// import PostDetail from '../pages/user/PostDetail';
+// import PostForm from '../pages/user/PostForm';
+// import MyPage from '../pages/user/MyPage';
+// import UserPage from '../pages/user/UserPage';
+// import Bookmark from '../pages/user/Bookmark';
+// import Settings from '../pages/user/Settings';
+//
+// const UserRouter = () => (
+//   <BrowserRouter>
+//     <ScrollToTop />
+//     <Routes>
+//       {/* 로그인 후 사용자 페이지 */}
+//       <Route element={<MainLayout />}>
+//         <Route path="/" element={<Home />} />
+//         <Route path="/postform" element={<PostForm />} />
+//         <Route path="/postdetail/:id" element={<PostDetail />} /> {/* 게시글 상세조회 */}
+//         <Route path="/mypage" element={<MyPage />} />
+//         <Route path="/userpage" element={<UserPage />} />
+//         <Route path="/bookmark" element={<Bookmark />} />
+//         <Route path="/settings" element={<Settings />} />
+//       </Route>
+//     </Routes>
+//   </BrowserRouter>
+// );
+//
+// export default UserRouter;


### PR DESCRIPTION
1. 레시피 작성 페이지-프론트와 연동하여 틀 만들어 놨습니다.
   상세 기능은 아직 구현 안 됐습니다.(이미지 업로드, 태그 등)
2. 게시글 작성 후 완료 버튼 클릭시 - 내용 상세 페이지로 이동하고, 상세 페이지 조회 가능하도록
    프론트와 연동하여 틀 작성해 놨습니다. db에 게시글 데이터 잘 들어가는 것까지 확인하였습니다.
3. approuter.jsx 파일은 공용이라 수정하지 않고, 개인 라우터 파일 추가하여 작성하고 싶었으나,
    중복되는 문제를 피하지 못해서, 조금 수정했습니다.
    이후 레시피 수정 페이지부터는 개인 라우터 파일 추가하여 거기서 코드 작성 및 추가하려고 합니다.

파일 제대로 올렸는지 확인 부탁드리고, 수정할 사항 있으면 말씀 주십시오.