### PR TITLE
Feature/admin

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/common/config/QuerydslConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.sloweat.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+  @PersistenceContext
+  private EntityManager em;
+
+  @Bean
+  public JPAQueryFactory queryFactory() {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/common/config/WebConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/common/config/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000") // React 개발 서버
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true); // 인증 정보(Cookie 등) 허용 시 true
     }


### PR DESCRIPTION
* WebConfig에 PATCH 추가
* QuerydslConfig 추가
QuerydslConfig는 JPAQueryFactory를 빈으로 등록해서 모든 Repository에서 편리하게 Querydsl을 사용할 수 있게하는 설정 클래스입니다!
