### PR TITLE
feat : 회원가입/로그인 로직 1차 구현

### DIFF
--- a/backend/sloweat/pom.xml
+++ b/backend/sloweat/pom.xml
@@ -80,6 +80,31 @@
             <artifactId>jakarta.persistence-api</artifactId>
             <version>3.1.0</version>
         </dependency>
+
+        <!--Security 의존성 추가-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- JWT 의존성 추가-->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth)->auth
                         //추후에 / -> 은 제거해야 함
-                        .requestMatchers("/auth/login","/auth/signup","/").permitAll()
+                        .requestMatchers("/api/auth/**","/").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 );

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.sloweat.domain.auth.config;
 
+import com.sloweat.domain.auth.jwt.JWTFilter;
 import com.sloweat.domain.auth.jwt.JWTUtil;
 import com.sloweat.domain.auth.jwt.LoginFilter;
 import com.sloweat.domain.auth.repository.RefreshRepository;
@@ -69,6 +70,10 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         //필터 추가
+        //JWTFilter
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil),LoginFilter.class);
+
         //LoginFilter
         http
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil, refreshRepository)

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth)->auth
                         //추후에 / -> 은 제거해야 함
-                        .requestMatchers("/api/auth/**","/","/login").permitAll()
+                        .requestMatchers("/api/auth/**","/login").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 );

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package com.sloweat.domain.auth.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity //시큐리티 활성화
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        //스프링 시큐리티 CORS 설정
+        http
+                .cors((cors)->cors.configurationSource(new CorsConfigurationSource() {
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+                        corsConfiguration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        corsConfiguration.setAllowedMethods(Collections.singletonList("*"));
+                        corsConfiguration.setAllowCredentials(true);
+                        corsConfiguration.setAllowedHeaders(Collections.singletonList("*"));
+                        corsConfiguration.setMaxAge(60*60L);
+                        corsConfiguration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return corsConfiguration;
+                    }
+                }));
+
+        //CSRF 비활성화
+        http
+                .csrf((csrf)->csrf.disable());
+
+        //FormLogin, httpBasic 비활성화
+        http
+                .formLogin((formLogin)->formLogin.disable());
+
+        http
+                .httpBasic((httpBasic)->httpBasic.disable());
+
+        //세션 stateless
+        http
+                .sessionManagement((sessionManagement)->sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        //필터 추가
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth)->auth
+                        //추후에 / -> 은 제거해야 함
+                        .requestMatchers("/auth/login","/auth/signup","/").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/controller/AuthController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/controller/AuthController.java
@@ -2,6 +2,9 @@ package com.sloweat.domain.auth.controller;
 
 import com.sloweat.domain.auth.dto.LocalSignupRequestDto;
 import com.sloweat.domain.auth.service.LocalSignupService;
+import com.sloweat.domain.auth.service.ReissueService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,11 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final LocalSignupService localSignupService;
-
+    private final ReissueService reissueService;
+    
+    //회원가입
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody LocalSignupRequestDto dto){
         localSignupService.signup(dto);
         System.out.println("controller진입");
         return ResponseEntity.ok("회원가입이 완료되었습니다.");
     }
+
+    //refresh -> access 토큰 재발급
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response){
+        return reissueService.reissue(request,response);
+    }
+
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/controller/AuthController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.sloweat.domain.auth.service.ReissueService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +26,9 @@ public class AuthController {
     public ResponseEntity<String> signup(@RequestBody LocalSignupRequestDto dto){
         localSignupService.signup(dto);
         System.out.println("controller진입");
-        return ResponseEntity.ok("회원가입이 완료되었습니다.");
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body("회원가입이 완료되었습니다.");
     }
 
     //refresh -> access 토큰 재발급

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/controller/AuthController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.sloweat.domain.auth.controller;
+
+import com.sloweat.domain.auth.dto.LocalSignupRequestDto;
+import com.sloweat.domain.auth.service.LocalSignupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final LocalSignupService localSignupService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody LocalSignupRequestDto dto){
+        localSignupService.signup(dto);
+        System.out.println("controller진입");
+        return ResponseEntity.ok("회원가입이 완료되었습니다.");
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/dto/CustomUserDetails.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/dto/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.sloweat.domain.auth.dto;
+
+import com.sloweat.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+//로컬 로그인용
+//todo:oauth2도 고려해야함
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+    
+    //권한 설정
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    //비밀번호 설정
+    @Override
+    public String getPassword() {
+        return user.getLocalPassword();
+    }
+    
+    //아이디 설정
+    @Override
+    public String getUsername() {
+        return user.getLocalEmail();
+    }
+    
+    /// 로그인 가능여부 설정
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+    
+    //Status=BANNED면 잠긴 계정으로 간주하고 false 반환
+    @Override
+    public boolean isAccountNonLocked() {
+        return user.getStatus() != User.Status.BANNED;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+    
+    //Status = ACTIVE 상태여야 로그인 가능
+    @Override
+    public boolean isEnabled() {
+        return user.getStatus() == User.Status.ACTIVE;
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/dto/LocalSignupRequestDto.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/dto/LocalSignupRequestDto.java
@@ -1,0 +1,16 @@
+package com.sloweat.domain.auth.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LocalSignupRequestDto {
+    //todo : 정확한 필드 검증, 이메일 인증로직, oauth2 추가
+    private String email;
+    private String password;
+    private String passwordConfirm;
+    private String nickname;
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/entity/Refresh.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/entity/Refresh.java
@@ -1,0 +1,25 @@
+package com.sloweat.domain.auth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+//Refresh 토큰 저장 위한 Entity
+public class Refresh {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Integer refreshId;
+
+    private String username; //id
+    private String refreshToken; //직전 refresh 토큰
+    private String expiration; //만료기간
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/JWTFilter.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/JWTFilter.java
@@ -1,0 +1,78 @@
+package com.sloweat.domain.auth.jwt;
+
+import com.sloweat.domain.auth.dto.CustomUserDetails;
+import com.sloweat.domain.user.entity.User;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+//매 요청마다 토큰을 꺼내서 인증 처리하는 필터
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //요청 헤더의 access 토큰 확인
+        String authorization = request.getHeader("Authorization");
+        
+        //없다면 다음 필터로 넘김
+        if(authorization == null || !authorization.startsWith("Bearer ")){
+            filterChain.doFilter(request,response);
+            return;
+        }
+        
+        //있다면 순수한 토큰을 얻음
+        String token = authorization.split(" ")[1]; //Bearer 접두사 제거
+
+        //access 토큰의 소멸 시간을 검증하여 유효한지 확인
+        try{
+            jwtUtil.isExpired(token);
+        }catch(ExpiredJwtException e){
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); //소멸 시간 초과
+            return;
+        }
+
+        //유효하다면 토큰이 access인지 확인
+        String category = jwtUtil.getCategory(token);
+        if(!category.equals("access")){
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); //access 토큰 아님
+            return;
+        }
+
+        //access 토큰이 맞다면 토큰에서 user 정보 획득
+        String localEmail = jwtUtil.getLocalEmail(token);
+        String role = jwtUtil.getRole(token);
+
+        //임시 인증용 user Entity 생성
+        User user = User.builder()
+                .localEmail(localEmail)
+                .localPassword("temppassword")
+                .role(User.Role.ROLE_USER)
+                .build();
+        
+        //시큐리티 인증
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails,null,customUserDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        
+        //다음 필터로 넘김
+        filterChain.doFilter(request,response);
+
+
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/JWTUtil.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/JWTUtil.java
@@ -1,0 +1,58 @@
+package com.sloweat.domain.auth.jwt;
+
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Component
+//JWT 토큰과 관련된 Util 클래스
+public class JWTUtil {
+
+    private final SecretKey secretKey;
+    
+    //시그니처 생성
+    public JWTUtil(@Value("${jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm() //대칭키 암호화
+        );
+    }
+
+    //jwt 토큰 생성
+    public String createJwt(String category, String localEmail, String role, Long expiredMs){
+        return Jwts.builder()
+                .claim("category",category)
+                .claim("localEmail",localEmail)
+                .claim("role",role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis()+expiredMs))
+                .signWith(secretKey)
+                .compact();
+
+    }
+
+    //jwt 토큰 검증
+    public String getCategory(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public String getLocalEmail(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("localEmail", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/LoginFilter.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/LoginFilter.java
@@ -1,0 +1,110 @@
+package com.sloweat.domain.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sloweat.domain.auth.dto.CustomUserDetails;
+import com.sloweat.domain.auth.entity.Refresh;
+import com.sloweat.domain.auth.repository.RefreshRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    //로그인 인증 진입 메소드
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        
+        //JSON 파싱
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String, String> requestMap = objectMapper.readValue(request.getInputStream(), Map.class);
+
+            String localEmail = requestMap.get("localEmail");
+            String password = requestMap.get("password");
+
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(localEmail, password);
+
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            throw new RuntimeException("로그인 JSON 파싱 실패", e);
+        }
+    }
+
+
+    //로그인 성공시
+    //jwt 토큰(access,refresh) 발급
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+
+        //Authentication -> 로그인한 사용자의 정보
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        //id
+        String localEmail = customUserDetails.getUsername(); //customUserDetails에서 현재 getUsername()은 localEmail을 반환
+
+        //role
+        String role = customUserDetails.getAuthorities().iterator().next().toString();
+
+        //토큰 생성
+        String access = jwtUtil.createJwt("access",localEmail,role,60*60*1000L); //1시간
+        String refresh = jwtUtil.createJwt("refresh",localEmail,role,24*60*60*1000L); //24시간
+
+        //refresh 토큰 저장
+        addRefreshEntity(localEmail,refresh,24*60*60*1000L);
+
+        //응답 설정
+        response.addHeader("Authorization", "Bearer " + access); //access 토큰 -> header 저장
+        response.addCookie(createCookie("refresh",refresh)); //refresh 토큰 -> 쿠키 저장
+        response.setStatus(HttpStatus.OK.value()); //상태값
+
+    }
+
+    //로그인 실패시
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    //refresh 토큰 DB 저장
+    private void addRefreshEntity(String localEmail,String refresh,Long expiredMs){
+
+        //현재 시간 + 만료 일자
+        Date date = new Date(System.currentTimeMillis()+expiredMs);
+
+        Refresh refreshEntity = Refresh.builder()
+                                       .username(localEmail)
+                                       .refreshToken(refresh)
+                                       .expiration(date.toString())
+                                       .build();
+
+        refreshRepository.save(refreshEntity);
+    }
+
+    //refresh 토큰 cookie 저장
+    private Cookie createCookie(String key, String value){
+        Cookie cookie = new Cookie(key,value);
+        cookie.setMaxAge(24*60*60); //24시간
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/LoginFilter.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/LoginFilter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 
+//todo : 명확한 에러 메세지 작성 -> 프론트 전달 고려
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/repository/AuthUserRepository.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/repository/AuthUserRepository.java
@@ -6,4 +6,5 @@ import com.sloweat.domain.user.entity.User;
 public interface AuthUserRepository extends JpaRepository<User,Integer> {
     Boolean existsBylocalEmail(String localEmail);
     Boolean existsBynickname(String nickname);
+    User findByLocalEmail(String localEmail);
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/repository/AuthUserRepository.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/repository/AuthUserRepository.java
@@ -1,0 +1,9 @@
+package com.sloweat.domain.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.sloweat.domain.user.entity.User;
+
+public interface AuthUserRepository extends JpaRepository<User,Integer> {
+    Boolean existsBylocalEmail(String localEmail);
+    Boolean existsBynickname(String nickname);
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/repository/RefreshRepository.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/repository/RefreshRepository.java
@@ -1,0 +1,9 @@
+package com.sloweat.domain.auth.repository;
+
+import com.sloweat.domain.auth.entity.Refresh;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshRepository extends JpaRepository<Refresh,Integer> {
+    Boolean existsByRefreshToken(String refresh);
+    void deleteByRefreshToken(String refresh);
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/service/CustomUserDetailsService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.sloweat.domain.auth.service;
+
+import com.sloweat.domain.auth.dto.CustomUserDetails;
+import com.sloweat.domain.auth.repository.AuthUserRepository;
+import com.sloweat.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AuthUserRepository authUserRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String localEmail) throws UsernameNotFoundException {
+        
+        //아이디로 객체 찾기
+        User user = authUserRepository.findByLocalEmail(localEmail);
+        
+        //존재한다면 CustomUserDetails 반환
+        if(user!=null){
+            return new CustomUserDetails(user);
+        }
+        
+        //존재하지 않는다면 예외 반환
+        throw new UsernameNotFoundException("이메일이 존재하지 않습니다: " + localEmail);
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/service/LocalSignupService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/service/LocalSignupService.java
@@ -1,0 +1,56 @@
+package com.sloweat.domain.auth.service;
+
+import com.sloweat.domain.auth.dto.LocalSignupRequestDto;
+import com.sloweat.domain.auth.repository.AuthUserRepository;
+import com.sloweat.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LocalSignupService {
+
+    private final AuthUserRepository authUserRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    
+    //local 회원가입
+    public void signup(LocalSignupRequestDto dto) {
+
+        String email = dto.getEmail();
+        String password = dto.getPassword();
+        String passwordConfirm = dto.getPasswordConfirm();
+        String nickname = dto.getNickname();
+        
+        //이메일 중복 검사
+        if(authUserRepository.existsBylocalEmail(email)){
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        //닉네임 중복 검사
+        if(authUserRepository.existsBynickname(nickname)){
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        //비밀번호 확인 일치 검사
+        if(!password.equals(passwordConfirm)) {
+            throw new IllegalArgumentException("비밀번호 확인이 일치하지 않습니다.");
+        }
+
+        //dto -> Entity (todo : User Entity 수정? default 값)
+        User user = User.builder()
+                .joinType(User.JoinType.LOCAL)
+                .localEmail(email)
+                .localPassword(bCryptPasswordEncoder.encode(password))
+                .nickname(nickname)
+                .role(User.Role.ROLE_USER)
+                .status(User.Status.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        authUserRepository.save(user);
+    }
+
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/service/ReissueService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/service/ReissueService.java
@@ -1,0 +1,98 @@
+package com.sloweat.domain.auth.service;
+
+import com.sloweat.domain.auth.entity.Refresh;
+import com.sloweat.domain.auth.jwt.JWTUtil;
+import com.sloweat.domain.auth.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class ReissueService {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @Transactional
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response){
+
+        //1. 쿠키에서 refresh 토큰 추출
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        for(Cookie cookie : cookies){
+            if(cookie.getName().equals("refresh")){
+                refreshToken = cookie.getValue();
+            }
+        }
+
+
+        if(refreshToken==null){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("refresh token null");
+        }
+        
+        //2. 만료 여부 확인
+        try{
+            jwtUtil.isExpired(refreshToken);
+        }catch (ExpiredJwtException e){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("refresh token expired");
+        }
+
+        //3. DB 존재 확인
+        Boolean isExist = refreshRepository.existsByRefreshToken(refreshToken);
+        if(!isExist){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("refresh token already exists");
+        }
+
+        //4. 새 토큰 발급
+        String localEmail = jwtUtil.getLocalEmail(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
+
+
+        String newAccess = jwtUtil.createJwt("access", localEmail, role, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", localEmail, role, 86400000L);
+
+        //5. DB 갱신
+        refreshRepository.deleteByRefreshToken(refreshToken);
+        addRefreshEntity(localEmail, newRefresh, 86400000L);
+
+        //6. 응답 설정
+        response.setHeader("Authorization", "Bearer " + newAccess);
+        response.addCookie(createCookie("refresh",newRefresh));
+
+        return ResponseEntity.ok().body("access token reissued");
+    }
+
+    //refresh 토큰 DB 저장
+    private void addRefreshEntity(String localEmail,String refresh,Long expiredMs){
+
+        //현재 시간 + 만료 일자
+        Date date = new Date(System.currentTimeMillis()+expiredMs);
+
+        Refresh refreshEntity = Refresh.builder()
+                .username(localEmail)
+                .refreshToken(refresh)
+                .expiration(date.toString())
+                .build();
+
+        refreshRepository.save(refreshEntity);
+    }
+
+    //refresh 토큰 cookie 저장
+    private Cookie createCookie(String key, String value){
+        Cookie cookie = new Cookie(key,value);
+        cookie.setMaxAge(24*60*60); //24시간
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/user/entity/User.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/user/entity/User.java
@@ -57,8 +57,8 @@ public class User {
     }
 
     public enum Role {
-        USER("사용자"),
-        ADMIN("관리자");
+        ROLE_USER("사용자"),
+        ROLE_ADMIN("관리자");
 
         private final String label;
 

--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -291,3 +291,15 @@ WHERE role = 'ROLE_USER';
 UPDATE user
 SET role = 'ADMIN'
 WHERE role = 'ROLE_ADMIN';
+
+-- 컬럼 enum 정의 및 DEFAULT 값 수정
+ALTER TABLE user
+MODIFY COLUMN role ENUM('ROLE_USER', 'ROLE_ADMIN') NOT NULL DEFAULT 'ROLE_USER';
+
+-- refresh 토큰 저장 용 테이블
+CREATE TABLE refresh (
+    refresh_id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    refresh_token TEXT NOT NULL,
+    expiration VARCHAR(255) NOT NULL
+);

--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -280,3 +280,14 @@ CREATE TABLE `recipe_tag` (
   CONSTRAINT `recipe_tag_ibfk_1` FOREIGN KEY (`recipe_id`) REFERENCES `recipe` (`recipe_id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `recipe_tag_ibfk_2` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`tag_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='레시피-태그';
+
+
+-- 기존 값 'ROLE_USER' → 'USER'
+UPDATE user
+SET role = 'USER'
+WHERE role = 'ROLE_USER';
+
+-- 기존 값 'ROLE_ADMIN' → 'ADMIN'
+UPDATE user
+SET role = 'ADMIN'
+WHERE role = 'ROLE_ADMIN';

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,11 +1,14 @@
 // src/App.js
 import './styles/global.css';
 import AppRouter from './routes/AppRouter';
+import AuthRouter from './routes/AuthRouter'; // 로그인 상태가 아닐 때만 보여줄 라우트
+
 
 function App() {
-    return (
-        <AppRouter></AppRouter>
-    )
+
+    const token = localStorage.getItem('accessToken');
+    
+   return token ? <AppRouter /> : <AuthRouter />;
 }
 
 export default App;

--- a/frontend/src/api/axiosInstance.js
+++ b/frontend/src/api/axiosInstance.js
@@ -2,6 +2,63 @@ import axios from 'axios';
 
 const axiosInstance = axios.create({
     baseURL: process.env.REACT_APP_API_BASE_URL,
+    withCredentials: true //쿠키 공유
 });
+
+//요청 인터셉터
+//API 요청을 서버로 보내기 전에 실행
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken');
+
+    //토큰이 존재하면 요청 헤더에 accessToken 추가
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+)
+
+//응답 인터셉터
+//서버로부터 응답을 받은 후 실행
+axiosInstance.interceptors.response.use(
+  (response) => response, //정상적인 응답 반환
+  async (error) => { 
+
+    //원본 요청 객체를 가져옴
+    const originalRequest = error.config;
+    
+    //오류 응답이 401 상태코드이고, 해당 요청이 재시도되지 않았다면 새 토큰을 신청
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        //새 토큰 요청하는 로직 실행
+        const res = await axios.post(
+          process.env.REACT_APP_API_BASE_URL + 'reissue',
+          {},
+          { withCredentials: true }
+        );
+
+        //새 토큰 저장
+        const newToken = res.headers['authorization']?.replace('Bearer ', '');
+        if (newToken) {
+          localStorage.setItem('accessToken', newToken);
+
+          //수정된 원본 요청으로 API 호출 재시도
+          originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+          return axios(originalRequest);
+        }
+      } catch (err) {
+        localStorage.removeItem('accessToken');
+        alert('다시 로그인 하시길 바랍니다.')
+        window.location.href = '/login';
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;

--- a/frontend/src/pages/user/Login.jsx
+++ b/frontend/src/pages/user/Login.jsx
@@ -1,12 +1,48 @@
 import { useState } from 'react';
+import {useNavigate} from 'react-router-dom';
+import axios from 'axios';
+
 import './Login.css';
 
 function Login() {
+ 
   const [showPassword, setShowPassword] = useState(false);
+  const [localEmail, setLocalEmail] = useState('');
+  const [password, setPassword] = useState('');
   
+  //비밀번호 보호
   const togglePasswordVisibility = () => {
     setShowPassword(!showPassword);
   };
+
+  //로그인
+  const handleLogin = async (e) => {
+    e.preventDefault();
+
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_API_BASE_URL}login`,
+        { localEmail, password },
+        {
+          headers: { 'Content-Type': 'application/json' },
+          withCredentials: true,
+        }
+      );
+
+      const accessToken = response.headers['authorization']?.replace('Bearer ', '');
+      if (accessToken) {
+        localStorage.setItem('accessToken', accessToken);
+        alert('로그인 성공!');
+        window.location.href = '/'; // 새로고침 -> 로그인 이후 페이지 라우팅
+      } else {
+        alert('accessToken을 받지 못했습니다.');
+      }
+    } catch (err) {
+      console.error('로그인 실패', err);
+      alert('로그인에 실패했습니다.');
+    }
+  };
+  
 
   return (
     <main className="login-container" data-model-id="19:12">
@@ -16,7 +52,9 @@ function Login() {
             <img src="https://c.animaapp.com/JlqecQMn/img/sloweat-logo-1@2x.png" alt="Slow Eat 로고" className="login-logo" />
             <p className="slogan">건강한 요리, 저속 노화의 시작</p>
           </header>
-          <form className="login-form">
+
+          <form className="login-form" onSubmit={handleLogin}>
+            {/* 아이디 입력(localEmail) */}
             <div className="form-group">
               <label htmlFor="username" className="form-label">아이디</label>
               <input
@@ -24,10 +62,14 @@ function Login() {
                 id="username"
                 name="username"
                 className="form-input"
+                value={localEmail}
+                onChange={(e) => setLocalEmail(e.target.value)}
                 placeholder="아이디를 입력하세요"
                 required
               />
             </div>
+
+            {/* 비밀번호 입력(password) */}
             <div className="form-group">
               <label htmlFor="password" className="form-label">비밀번호</label>
               <div className="password-input-wrapper">
@@ -36,6 +78,8 @@ function Login() {
                   id="password"
                   name="password"
                   className="form-input"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
                   placeholder="비밀번호를 입력하세요"
                   required
                 />

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -89,8 +89,8 @@ const AppRouter = () => (
     <ScrollToTop />
     <Routes>
       {/* 공통 - 로그인, 회원가입 페이지 */}
-      <Route path="/login" element={<Login />} />
-      <Route path="/signUp" element={<SignUp />} />
+      <Route path="/auth/login" element={<Login />} />
+      <Route path="/auth/signUp" element={<SignUp />} />
 
       {/* 로그인 이후 user 페이지 */}
       <Route element={<MainLayout />}>

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -89,8 +89,8 @@ const AppRouter = () => (
     <ScrollToTop />
     <Routes>
       {/* 공통 - 로그인, 회원가입 페이지 */}
-      <Route path="/auth/login" element={<Login />} />
-      <Route path="/auth/signUp" element={<SignUp />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/signUp" element={<SignUp />} />
 
       {/* 로그인 이후 user 페이지 */}
       <Route element={<MainLayout />}>

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -63,8 +63,7 @@
 
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import ScrollToTop from '../utils/ScrollToTop';
-import Login from '../pages/user/Login';
-import SignUp from '../pages/user/SignUp';
+
 import MainLayout from '../layouts/user/MainLayout';
 import Home from '../pages/user/Home';
 import Search from '../pages/user/Search';
@@ -88,12 +87,10 @@ const AppRouter = () => (
   <BrowserRouter>
     <ScrollToTop />
     <Routes>
-      {/* 공통 - 로그인, 회원가입 페이지 */}
-      <Route path="/login" element={<Login />} />
-      <Route path="/signUp" element={<SignUp />} />
 
       {/* 로그인 이후 user 페이지 */}
       <Route element={<MainLayout />}>
+        <Route path="*" element={<Navigate to="/" replace />} />
         <Route path="/" element={<Home />} />
         <Route path="/search" element={<Search />} />
         <Route path="/membership" element={<Membership />} />

--- a/frontend/src/routes/AuthRouter.jsx
+++ b/frontend/src/routes/AuthRouter.jsx
@@ -1,0 +1,17 @@
+import { Routes, Route, Navigate,BrowserRouter } from 'react-router-dom';
+import Login from '../pages/user/Login';
+import SignUp from '../pages/user/SignUp';
+
+const AuthRouter = () => (
+    <BrowserRouter>
+        <Routes>
+        {/* 공통 - 로그인, 회원가입 페이지 */}
+            <Route path="/login" element={<Login />} />
+            <Route path="/signUp" element={<SignUp />} />
+            <Route path="*" element={<Navigate to="/login" replace />} />
+        </Routes>
+    </BrowserRouter>
+
+);
+
+export default AuthRouter;


### PR DESCRIPTION
# JWT(accessToken, refreshToken) 기반 로그인/회원가입 1차 구현
- jwt 기반 로그인/회원가입 로직 구현을 위해 **pom.xml에 의존성을 추가**하였습니다. (security + jwt 관련)
- jwt 시그니처 secret 키는 **application.properties에 명시**하면 됩니다.

  예시)
  jwt:
    secret: e15814ce670a0e0b61c944f5c69b7ebd

- refreshToken을 저장하고 관리하기 위해 **refresh entity를 생성**하였습니다.
- security를 원활하게 사용하기 위해 User 테이블의 **role Enum타입에 ROLE_ 접두사를 붙여 수정**하였습니다.

## [백엔드] 회원가입 로직 구현
- 유효성 검사는 하지 않은 간단한 회원가입 로직을 구현하였습니다.
- 프론트엔드는 연동이 되지 않은 상태입니다.

## [프론트/백엔드] 로그인 로직 구현
- 백엔드
  - 로그인 성공 -> cookie에 refresh 토큰을, header에 access 토큰을 저장하도록 하였습니다.
  - access  토큰 만료 -> /reissue controller를 통해 기존 refresh 토큰을 제거하고 refresh 토큰과 access 토큰을 재발급 받도록 하였습니다.
 
- 프론트
  - 로그인 전 (accessToken 보유 여부) 에는 로그인 페이지와 회원가입 페이지만 접근 할 수 있게끔 라우터 분기처리를 하였습니다. (권한에 따른 분기처리는 아직 X)
  - axiosInstance.js에 요청/응답 interceptor를 구현하여 모든 요청에 accessToken을 자동으로 추가하고, 401 응답 시 access 토큰을 재발급받아 요청을 자동 재시도하도록 구현하였습니다.

<hr>

jwt 로그인/회원가입 구현은 처음이라 맞는 코드의 흐름인지 잘 모르겠습니다 😢 엉엉
어째 백보다 프론트 처리가 더 어려운듯합니다...ㅠ0ㅠ
많은 피드백 부탁드립니다!!!
