### PR TITLE
feat: 구독 갱신 기능 추가 

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/common/config/ScheduleConfig.java
+++ b/backend/sloweat/src/main/java/com/sloweat/common/config/ScheduleConfig.java
@@ -1,0 +1,9 @@
+package com.sloweat.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/payment/entity/Payment.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/payment/entity/Payment.java
@@ -25,6 +25,12 @@ public class Payment {
     @JoinColumn(name = "subscription_id", nullable = false)
     private Subscription subscription;
 
+    @Column(name = "imp_uid", unique = true, nullable = false, length = 100)
+    private String impUid;
+
+    @Column(name = "merchant_uid", unique = true, nullable = false, length = 100)
+    private String merchantUid;
+
     private Integer amount;
 
     @Enumerated(EnumType.STRING)

--- a/backend/sloweat/src/main/java/com/sloweat/domain/subscription/controller/SubscriptionController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/subscription/controller/SubscriptionController.java
@@ -34,4 +34,13 @@ public class SubscriptionController {
         SubscriptionResponse response = subscriptionService.getSubscription(id);
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 구독 갱신
+     */
+    @PatchMapping("/subscription/{id}/renew")
+    public ResponseEntity<SubscriptionResponse> renewSubscription(@PathVariable Integer id) {
+        SubscriptionResponse response = subscriptionService.renewSubscription(id);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/subscription/entity/Subscription.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/subscription/entity/Subscription.java
@@ -23,7 +23,7 @@ public class Subscription {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(unique = true, nullable = false)
+    @Column(name = "customer_uid",unique = true, nullable = false)
     private String customerUid;  // 빌링키 (아임포트)
 
     private LocalDateTime startDate;

--- a/backend/sloweat/src/main/java/com/sloweat/domain/subscription/scheduler/SubscriptionScheduler.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/subscription/scheduler/SubscriptionScheduler.java
@@ -1,0 +1,34 @@
+
+package com.sloweat.domain.subscription.scheduler;
+
+import com.sloweat.domain.subscription.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionScheduler {
+
+    private final SubscriptionService subscriptionService;
+
+    /**
+     * 매일 오전 9시에 자동 갱신 처리
+     */
+   // @Scheduled(cron = "0 0 9 * * *")
+
+    //  테스트를 위해 매 10분마다 실행 (00, 10, 20, 30, 40, 50분)
+    @Scheduled(cron = "0 0/10 * * * *")
+    public void processAutoRenewal() {
+        log.info("자동 갱신 시작 ~~~");
+        try {
+            subscriptionService.processAutoRenewal();
+            log.info("자동 갱신완료");
+        } catch (Exception e) {
+            log.error("갱신 중 오류 발생 ", e);
+        }
+    }
+
+}

--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -186,11 +186,13 @@ CREATE TABLE `comment_report` (
 CREATE TABLE `subscription` (
   `subscription_id` int NOT NULL AUTO_INCREMENT,
   `user_id` int DEFAULT NULL COMMENT '구독자',
+  `customer_uid` VARCHAR(100) NOT NULL COMMENT '아임포트 결제 고유 ID',
   `status` enum('ACTIVE','CANCEL','EXPIRE') NOT NULL DEFAULT 'ACTIVE',
   `start_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `end_date` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`subscription_id`),
+  UNIQUE KEY `customer_uid` (`customer_uid`),
   KEY `user_id` (`user_id`),
   CONSTRAINT `subscription_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='구독';
@@ -242,6 +244,8 @@ CREATE TABLE `follow` (
 CREATE TABLE `payment` (
   `payment_id` int NOT NULL AUTO_INCREMENT,
   `subscription_id` int DEFAULT NULL COMMENT '구독 정보',
+  `imp_uid` VARCHAR(100) NOT NULL COMMENT '아임포트 결제 고유 ID',
+  `merchant_uid` VARCHAR(100) NOT NULL COMMENT '가맹점 주문 고유 ID',
   `amount` int NOT NULL COMMENT '결제금액',
   `status` enum('PAID','CANCEL','REFUND') NOT NULL,
   `method` enum('CARD','CASH') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
@@ -251,6 +255,8 @@ CREATE TABLE `payment` (
   `refund_date` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NOT NULL,
   PRIMARY KEY (`payment_id`),
+  UNIQUE KEY `imp_uid` (`imp_uid`),
+  UNIQUE KEY `merchant_uid` (`merchant_uid`),
   KEY `subscription_id` (`subscription_id`),
   CONSTRAINT `payment_ibfk_1` FOREIGN KEY (`subscription_id`) REFERENCES `subscription` (`subscription_id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='결제정보';


### PR DESCRIPTION
## 구독 갱신 기능 추가 
자동 구독 갱신 기능 과 수동 구독 갱신 기능 추가  
자동 구독 갱신을 위한 스케줄러 설정 파일 및 스케쥴러 파일 추가 

## ddl 업데이트 및 관련 엔티티 업데이트 
payment 테이블 및 엔티티에 imp_uid , merchant_uid  추가 Subscription 엔티티 및 테이블에 customer_id 추가
관련 메소드에 해당 필드 값들 추가  


