### PR TITLE
통계 리포트 정보 가져오는 로직 구현

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/domain/admin/controller/AdminStatisticsController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/admin/controller/AdminStatisticsController.java
@@ -1,0 +1,23 @@
+package com.sloweat.domain.admin.controller;
+
+import com.sloweat.domain.admin.dto.statistics.AdminStatisticsResponse;
+import com.sloweat.domain.admin.service.AdminStatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// TODO: 관리자 권한 체크 (PreAuthorize 적용 예정)
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminStatisticsController {
+  private final AdminStatisticsService adminStatisticsService;
+
+  @GetMapping("/statistics")
+  public ResponseEntity<AdminStatisticsResponse> getStatistics() {
+    AdminStatisticsResponse response = adminStatisticsService.getStatistics();
+    return ResponseEntity.ok(response);
+  }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/admin/dto/statistics/AdminStatisticsResponse.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/admin/dto/statistics/AdminStatisticsResponse.java
@@ -1,0 +1,30 @@
+package com.sloweat.domain.admin.dto.statistics;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminStatisticsResponse {
+  private Long totalSales;      // 총 매출
+  private Long paidUserCount;   // 유료 회원 수
+  private Long totalUserCount;  // 전체 회원 수
+
+  private List<MonthlySales> monthlySales;      // 최근 6개월 매출
+  private List<MonthlySignups> monthlySignups;  // 최근 6개월 가입 수
+
+  @Getter
+  @AllArgsConstructor
+  public static class MonthlySales {
+    private String month;
+    private Long totalSales;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class MonthlySignups {
+    private String month;
+    private Long signupCount;
+  }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/admin/repository/statistics/AdminStatisticsRepository.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/admin/repository/statistics/AdminStatisticsRepository.java
@@ -1,0 +1,13 @@
+package com.sloweat.domain.admin.repository.statistics;
+
+import com.sloweat.domain.admin.dto.statistics.AdminStatisticsResponse.MonthlySales;
+import com.sloweat.domain.admin.dto.statistics.AdminStatisticsResponse.MonthlySignups;
+import java.util.List;
+
+public interface AdminStatisticsRepository {
+  Long getTotalSales();
+  Long getPaidUserCount();
+  Long getTotalUserCount();
+  List<MonthlySales> getMonthlySales();
+  List<MonthlySignups> getMonthlySignups();
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/admin/repository/statistics/AdminStatisticsRepositoryImpl.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/admin/repository/statistics/AdminStatisticsRepositoryImpl.java
@@ -1,0 +1,101 @@
+package com.sloweat.domain.admin.repository.statistics;
+
+import com.sloweat.domain.admin.dto.statistics.AdminStatisticsResponse.MonthlySales;
+import com.sloweat.domain.admin.dto.statistics.AdminStatisticsResponse.MonthlySignups;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+// date_format, interval, limit 같은 db 종속 함수를 사용하기 위해 NavtiveQuery  이용
+// QueryDsl이나 JPQL 쓸 경우 오히려 복잡
+@Repository
+public class AdminStatisticsRepositoryImpl implements  AdminStatisticsRepository {
+
+  @PersistenceContext
+  private EntityManager em;   // SQL 직접 실행, DTO로 결과 매핑, 복잡한 통계 쿼리 실행
+
+  @Override
+  public Long getTotalSales() {
+    // coalesce : 인자로 받은 값들 중에서 null이 아닌 첫 번째 값을 반환
+    // 결제 상태가 PAID인 결제 금액의 총합을 구함. 결제가 없을 경우 0 반환.
+    String sql = "select coalesce(sum(p.amount), 0)\n"
+        + "from payment p\n"
+        + "where p.status = 'PAID'";
+    return ((Number) em.createNativeQuery(sql).getSingleResult()).longValue();
+  }
+
+  @Override
+  public Long getPaidUserCount() {
+    // 구독 테이블에서 구독 상태가 'ACTIVE'인 유저 수 카운트
+    String sql = "select count(*)\n"
+        + "from subscription s\n"
+        + "where s.status='ACTIVE'";
+    return ((Number) em.createNativeQuery(sql).getSingleResult()).longValue();
+  }
+
+  @Override
+  public Long getTotalUserCount() {
+    // 전체 사용자 수 카운트
+    String sql = "select count(*)\n"
+        + "from user";
+    return ((Number) em.createNativeQuery(sql).getSingleResult()).longValue();
+  }
+
+  @Override
+  public List<MonthlySales> getMonthlySales() {
+    // 최근 6개월간 결제된 금액을 월별로 집계하여 가장 최근부터 6개월치 가져옴. 없으면 0 가져옴.
+    // 이때, 현재 월은 포함X. 현재 2025년 7월이면 7월 제외하고 2025년 1월 ~ 6월 가져옴.
+    String sql = "with recursive months as(\n"
+        + "\tselect date_format(date_sub(curdate(), interval 6 month), '%Y-%m') as month\n"
+        + "    union all\n"
+        + "    select date_format(date_add(str_to_date(concat(month, '-01'), '%Y-%m-%d'), interval 1 month), '%Y-%m')\n"
+        + "\tfrom months\n"
+        + "    where month < date_format(date_sub(curdate(), interval 1 month), '%Y-%m')\n"
+        + ")\n"
+        + "select m.month, coalesce(sum(p.amount), 0) as totalSales\n"
+        + "from months m\n"
+        + "left join payment p\n"
+        + "\ton date_format(p.pay_date, '%Y-%m') = m.month\n"
+        + "    and p.status = 'PAID'\n"
+        + "group by m.month\n"
+        + "order by m.month desc";
+
+    List<Object[]> resultList = em.createNativeQuery(sql).getResultList();
+
+    return resultList.stream()
+        .map(row -> new MonthlySales(
+            (String) row[0],
+            ((Number) row[1]).longValue()
+        ))
+        .toList();
+  }
+
+  @Override
+  public List<MonthlySignups> getMonthlySignups() {
+    // 최근 6개월간 사용자 가입 수를 월별로 집계하여 가장 최근부터 6개월치 가져옴. 없으면 0 가져옴.
+    // 이때, 현재 월은 포함X. 현재 2025년 7월이면 7월 제외하고 2025년 1월 ~ 6월 가져옴.
+    String sql = "with recursive months as(\n"
+        + "\tselect date_format(date_sub(curdate(), interval 6 month), '%Y-%m') as month\n"
+        + "    union all\n"
+        + "    select date_format(date_add(str_to_date(concat(month, '-01'), '%Y-%m-%d'), interval 1 month), '%Y-%m')\n"
+        + "\tfrom months\n"
+        + "    where month < date_format(date_sub(curdate(), interval 1 month), '%Y-%m')\n"
+        + ")\n"
+        + "select m.month, coalesce(count(u.user_id), 0) as signupCount\n"
+        + "from months m\n"
+        + "left join user u\n"
+        + "\ton date_format(u.created_at, '%Y-%m') = m.month\n"
+        + "group by m.month\n"
+        + "order by m.month desc";
+
+    List<Object[]> resultList = em.createNativeQuery(sql).getResultList();
+
+    return resultList.stream()
+        .map(row -> new MonthlySignups(
+            (String) row[0],
+            ((Number) row[1]).longValue()
+        ))
+        .toList();
+  }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/admin/service/AdminStatisticsService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/admin/service/AdminStatisticsService.java
@@ -1,0 +1,23 @@
+package com.sloweat.domain.admin.service;
+
+import com.sloweat.domain.admin.dto.statistics.AdminStatisticsResponse;
+import com.sloweat.domain.admin.repository.statistics.AdminStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminStatisticsService {
+  private final AdminStatisticsRepository adminStatisticsRepository;
+
+  // repository 결과를 하나로 모아서 하나의 dto로 통합하여 전달
+  public AdminStatisticsResponse getStatistics(){
+    return new AdminStatisticsResponse(
+        adminStatisticsRepository.getTotalSales(),
+        adminStatisticsRepository.getPaidUserCount(),
+        adminStatisticsRepository.getTotalUserCount(),
+        adminStatisticsRepository.getMonthlySales(),
+        adminStatisticsRepository.getMonthlySignups()
+    );
+  }
+}


### PR DESCRIPTION
* 통계 리포트에 들어갈 내용들 한번에 모아서 전달하는 형태로 구현
* date_format, interval, limit 같은 db 종속 함수를 사용하는 경우 QueryDSL이나 JPQL을 사용할 때보다 오히려 복잡해서 NativeQuery를 이용