### PR TITLE
feat: follower/follwing list and set follow/unfollow

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/domain/follow/controller/FollowController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/follow/controller/FollowController.java
@@ -1,11 +1,13 @@
 package com.sloweat.domain.follow.controller;
 
+import com.sloweat.domain.auth.dto.CustomUserDetails;
 import com.sloweat.domain.follow.dto.FollowRequestDto;
 import com.sloweat.domain.follow.dto.FollowResponseDto;
 import com.sloweat.domain.follow.service.FollowService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,41 +23,41 @@ public class FollowController {
     @PostMapping("/follow")
     public ResponseEntity<Void> follow(
             @RequestBody FollowRequestDto requestDto,
-            HttpSession session) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        Integer fromUserId = 1;
+        Integer fromUserId = userDetails.getUserId();
 
         followService.follow(fromUserId, requestDto);
         return ResponseEntity.ok().build();
     }
 
     // 언팔로우 요청
-    @DeleteMapping("/follow")
+    @DeleteMapping("/follow/{userId}")
     public ResponseEntity<Void> unfollow(
-            @RequestParam("toUserId") Integer toUserId,
-            HttpSession session) {
+            @PathVariable Integer userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        Integer fromUserId = 1;
+        Integer fromUserId = userDetails.getUserId();
 
-        followService.unfollow(fromUserId, toUserId);
+        followService.unfollow(fromUserId, userId);
         return ResponseEntity.ok().build();
     }
 
     // 팔로워 목록
     @GetMapping("/followers")
     public ResponseEntity<List<FollowResponseDto>> getFollowers(
-            HttpSession session) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        Integer userId = 1;
+        Integer userId = userDetails.getUserId();
         return ResponseEntity.ok(followService.getFollowers(userId));
     }
 
     // 팔로잉 목록
     @GetMapping("/followings")
     public ResponseEntity<List<FollowResponseDto>> getFollowings(
-            HttpSession session) {
-        Integer userId = 1;
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
+        Integer userId = userDetails.getUserId();
         return ResponseEntity.ok(followService.getFollowings(userId));
     }
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/follow/dto/FollowResponseDto.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/follow/dto/FollowResponseDto.java
@@ -1,18 +1,19 @@
 package com.sloweat.domain.follow.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
-@Getter
-@Setter
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class FollowResponseDto {
+    private Integer followId;
     private Integer userId;
+    private String nickname;
+    private String profileImgPath;
     private String localEmail;
     private String kakaoEmail;
-    private String profileImagPath;
-    private String nickname;
-    private String username;
-    private Integer followerCount;
+    private Long followerCount;
+    private Boolean isFollowed;
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/follow/repository/FollowRepository.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/follow/repository/FollowRepository.java
@@ -1,8 +1,11 @@
 package com.sloweat.domain.follow.repository;
 
+import com.sloweat.domain.follow.dto.FollowResponseDto;
 import com.sloweat.domain.follow.entity.Follow;
 import com.sloweat.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +20,6 @@ public interface FollowRepository extends JpaRepository<Follow,Integer> {
 
     long countByFollower(User follower);
     long countByFollowing(User following);
+
+    Optional<Follow> findByFollower_UserIdAndFollowing_UserId(Integer userId, Integer followingId);
 }

--- a/backend/sloweat/src/main/java/com/sloweat/domain/follow/repository/FollowRepositoryCumstom.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/follow/repository/FollowRepositoryCumstom.java
@@ -1,0 +1,14 @@
+package com.sloweat.domain.follow.repository;
+
+import com.sloweat.domain.follow.dto.FollowResponseDto;
+
+import java.util.List;
+
+public interface FollowRepositoryCumstom {
+
+    //팔로워 목록 조회
+    public List<FollowResponseDto> getFollowers(Integer userId);
+
+    //팔로잉 목록 조회
+    List<FollowResponseDto> getFollowings(Integer userId);
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/follow/repository/FollowRepositoryCustomImpl.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/follow/repository/FollowRepositoryCustomImpl.java
@@ -1,0 +1,105 @@
+package com.sloweat.domain.follow.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sloweat.domain.admin.dto.comment.AdminCommentResponse;
+import com.sloweat.domain.admin.dto.comment.QAdminCommentResponse;
+import com.sloweat.domain.comment.entity.QComment;
+import com.sloweat.domain.comment.entity.QCommentReport;
+import com.sloweat.domain.follow.dto.FollowResponseDto;
+import com.sloweat.domain.follow.entity.QFollow;
+import com.sloweat.domain.user.entity.QUser;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class FollowRepositoryCustomImpl implements FollowRepositoryCumstom{
+
+    private final JPAQueryFactory queryFactory;
+
+    public FollowRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<FollowResponseDto> getFollowers(Integer targetUserId) {
+        QFollow a = QFollow.follow;
+        QUser b = QUser.user;
+        QFollow c = new QFollow("c"); // for follower count
+        QFollow d = new QFollow("d"); // for is_following check
+
+        return queryFactory
+                .select(Projections.constructor(FollowResponseDto.class,
+                        a.followId,
+                        b.userId,
+                        b.nickname,
+                        b.profileImgPath,
+                        b.localEmail,
+                        b.kakaoEmail,
+
+                        // follower count (서브쿼리)
+                        JPAExpressions
+                                .select(c.count())
+                                .from(c)
+                                .where(c.following.userId.eq(b.userId)),
+
+                        // is_following (내가 그 사람을 팔로우 중인지 여부)
+                        JPAExpressions
+                                .select(Wildcard.count)
+                                .from(d)
+                                .where(
+                                        d.follower.userId.eq(targetUserId)
+                                                .and(d.following.userId.eq(b.userId))
+                                )
+                                .gt(0L) // count > 0 → true
+                ))
+                .from(a)
+                .join(b).on(a.follower.userId.eq(b.userId))
+                .where(a.following.userId.eq(targetUserId))
+                .fetch();
+    }
+
+    @Override
+    public List<FollowResponseDto> getFollowings(Integer targetUserId) {
+
+        QFollow a = QFollow.follow;
+        QUser b = QUser.user;
+        QFollow c = new QFollow("c"); // for follower count
+        QFollow d = new QFollow("d"); // for is_following check
+
+        return queryFactory
+                .select(Projections.constructor(FollowResponseDto.class,
+                        a.followId,
+                        b.userId,
+                        b.nickname,
+                        b.profileImgPath,
+                        b.localEmail,
+                        b.kakaoEmail,
+
+                        // follower count (서브쿼리)
+                        JPAExpressions
+                                .select(c.count())
+                                .from(c)
+                                .where(c.following.userId.eq(b.userId)),
+
+                        // is_following (내가 그 사람을 팔로우 중인지 여부)
+                        JPAExpressions
+                                .select(Wildcard.count)
+                                .from(d)
+                                .where(
+                                        d.follower.userId.eq(targetUserId)
+                                                .and(d.following.userId.eq(b.userId))
+                                )
+                                .gt(0L) // count > 0 → true
+                ))
+                .from(a)
+                .join(b).on(a.following.userId.eq(b.userId))
+                .where(a.follower.userId.eq(targetUserId))
+                .fetch();
+    }
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/follow/service/FollowService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/follow/service/FollowService.java
@@ -4,6 +4,7 @@ import com.sloweat.domain.follow.dto.FollowRequestDto;
 import com.sloweat.domain.follow.dto.FollowResponseDto;
 import com.sloweat.domain.follow.entity.Follow;
 import com.sloweat.domain.follow.repository.FollowRepository;
+import com.sloweat.domain.follow.repository.FollowRepositoryCumstom;
 import com.sloweat.domain.user.entity.User;
 import com.sloweat.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,6 +22,7 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+    private final FollowRepositoryCumstom  followRepositoryCumstom;
 
     // 팔로우 하기
     @Transactional
@@ -31,9 +34,9 @@ public class FollowService {
                 .orElseThrow(() -> new EntityNotFoundException("팔로우 대상 사용자 없음"));
 
         // 이미 팔로우 중이면 무시
-        if (followRepository.findByFollowerAndFollowing(fromUser, toUser).isPresent()) {
+        /*if (followRepository.findByFollowerAndFollowing(fromUser, toUser).isPresent()) {
             throw new IllegalStateException("이미 팔로우 중입니다.");
-        }
+        }*/
 
         Follow follow = new Follow();
         follow.setFollower(fromUser);
@@ -43,17 +46,23 @@ public class FollowService {
 
     // 언팔로우 하기
     @Transactional
-    public void unfollow(Integer fromUserId, Integer toUserId) {
-        User fromUser = userRepository.findById(fromUserId)
+    public void unfollow(Integer userId, Integer followingId) {
+
+
+        Optional<Follow> follow = followRepository.findByFollower_UserIdAndFollowing_UserId(userId, followingId);
+        follow.ifPresent(f -> followRepository.delete(f));
+
+
+      /*  User fromUser = userRepository.findById(fromUserId)
                 .orElseThrow(() -> new EntityNotFoundException("로그인한 사용자 없음"));
 
-        User toUser = userRepository.findById(toUserId)
+        User toUser = userRepository.findById(request.getToUserId())
                 .orElseThrow(() -> new EntityNotFoundException("대상 사용자 없음"));
 
         Follow follow = followRepository.findByFollowerAndFollowing(fromUser, toUser)
-                .orElseThrow(() -> new EntityNotFoundException("팔로우 관계가 존재하지 않습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("팔로우 관계가 존재하지 않습니다."));*/
 
-        followRepository.delete(follow);
+        //followRepository.deleteById(followId);
     }
 
     // 팔로워 목록 조회
@@ -62,15 +71,10 @@ public class FollowService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자 없음"));
 
-        // 나를 친구로 추가한 사람
-        return followRepository.findByFollowing(user).stream()
-                .map(f -> FollowResponseDto.builder()
-                        .userId(f.getFollower().getUserId())
-                        .profileImagPath(f.getFollower().getProfileImgPath())
-                        .nickname(f.getFollower().getNickname())
-                        .localEmail(f.getFollower().getLocalEmail())
-                        .kakaoEmail(f.getFollower().getKakaoEmail()).build()
-                ).collect(Collectors.toList());
+        List<FollowResponseDto> followers = followRepositoryCumstom.getFollowers(userId);
+
+        return followers;
+
     }
 
     // 팔로잉 목록 조회
@@ -79,16 +83,8 @@ public class FollowService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자 없음"));
 
-        // 내가 친구로 추가한 사람
-        return followRepository.findByFollower(user).stream()
-                .map(f -> FollowResponseDto.builder()
-                                .userId(f.getFollowing().getUserId())
-                                .profileImagPath(f.getFollowing().getProfileImgPath())
-                                .nickname(f.getFollowing().getNickname())
-                                .localEmail(f.getFollowing().getLocalEmail())
-                                .kakaoEmail(f.getFollowing().getKakaoEmail()).build()
-                ).collect(Collectors.toList());
+        List<FollowResponseDto> followings = followRepositoryCumstom.getFollowings(userId);
+
+        return followings;
     }
-
-
 }

--- a/frontend/src/components/follow_modal/FollowCard.jsx
+++ b/frontend/src/components/follow_modal/FollowCard.jsx
@@ -1,19 +1,43 @@
-import React, { useState } from "react";
+import React, {useEffect, useState} from "react";
 import { useNavigate  } from "react-router-dom";
 import "./FollowCard.css";
+import api from "../../api/axiosInstance";
 
 export const FollowCard = ({
+  followId,
   username,
   userId,
   followerCount,
   profileImg,
-  isFollowing: initialFollowing = false,
+  isFollowed: initialFollowing = false,
+  email
 }) => {
-  const [isFollowing, setIsFollowing] = useState(initialFollowing);
+  const [isFollowed, setIsFollowed] = useState(initialFollowing);
 
   const handleFollowToggle = () => {
-    setIsFollowing((prev) => !prev);
-    // 여기서 API 요청도 함께 처리하면 됨 (예: follow/unfollow)
+    if(isFollowed) {
+      setUnFollow();
+    }else{
+      setFollow();
+    }
+    setIsFollowed((prev) => !prev);
+  };
+
+  const setFollow = async () => {
+    try {
+      await api.post('api/follow', {toUserId : userId});
+    } catch (error) {
+      console.error('팔로우 설정 실패:', error);
+    }
+  };
+
+  const setUnFollow = async () => {
+    try {
+      const response = await api.delete(`api/follow/${userId}`); //Unfollow 대상 userId
+
+    } catch (error) {
+      console.error('언팔로우 설정 실패:', error);
+    }
   };
 
   const navigate = useNavigate();
@@ -29,16 +53,16 @@ export const FollowCard = ({
         <img className="profile-img" src={profileImg} alt="Profile" />
 
         <div className="username">{username}</div>
-        <div className="user-id">{userId}</div>
+        <div className="user-id">{email}</div>
         <div className="follower-count-label">팔로워</div>
         <div className="follower-count">{followerCount}</div>
 
         <div className="follow-button-wrapper">
           <div
-            className={`follow-button ${isFollowing ? "following" : "not-following"}`}
+            className={`follow-button ${isFollowed ? "following" : "not-following"}`}
             onClick={handleFollowToggle}
           >
-            {isFollowing ? "팔로잉" : "팔로우"}
+            {isFollowed ? "팔로잉" : "팔로우"}
           </div>
         </div>
       </div>

--- a/frontend/src/components/follow_modal/FollowHeader.jsx
+++ b/frontend/src/components/follow_modal/FollowHeader.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import "./FollowHeader.css";
 
 export const FollowHeader = ({activeTab, setActiveTab, onClose}) => {
+
   return (
     <div className="follow-header">
       <div className="header-container">

--- a/frontend/src/components/follow_modal/FollowModal.jsx
+++ b/frontend/src/components/follow_modal/FollowModal.jsx
@@ -1,48 +1,65 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import { FollowHeader } from "./FollowHeader";
 import { FollowCard } from "./FollowCard";
 import "./FollowModal.css";
+import api from "../../api/axiosInstance";
 
 export const FollowModal = ({ isOpen, onClose, initialTab = "followers" }) => {
   const [activeTab, setActiveTab] = useState(initialTab);
 
-  
-  React.useEffect(() => {
+  //목록 데이터
+  const [userList, setUserList] = useState([]);
+
+  //사용자 아이디
+  //const userId = 1;
+
+  const fetchFollowers = async () => {
+    try {
+      const response = await api.get('api/followers');
+      setUserList(response.data);
+    } catch (error) {
+      console.error('북마크 컬렉션 불러오기 실패:', error);
+    }
+  };
+
+  const fetchFollowings = async () => {
+    try {
+      const response = await api.get('api/followings');
+      setUserList(response.data);
+    } catch (error) {
+      console.error('북마크 컬렉션 불러오기 실패:', error);
+    }
+  };
+
+  useEffect(() => {
     if (isOpen) setActiveTab(initialTab);
-  }, [isOpen, initialTab]);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (activeTab === 'followers') {
+      fetchFollowers();
+    }else{
+      fetchFollowings();
+    }
+  }, [activeTab]);
 
   if (!isOpen) return null;
 
-  const followers = [
-    { username: "베이킹퀸", id: "@baking_queen", count: "12.5K", following: true, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-    { username: "파스타마스터", id: "@pasta_master", count: "8.3K", following: true, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-    { username: "홈쿡킹", id: "@home_cooking", count: "15.2K", following: false, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-    { username: "건강요리사", id: "@healthy_chef", count: "6.7K", following: true, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-    { username: "디저트퀸", id: "@dessert_queen", count: "9.1K", following: false, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-  ];
-
-  const followings = [
-    { username: "홈쿡킹", id: "@home_cooking", count: "15.2K", following: false, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-    { username: "건강요리사", id: "@healthy_chef", count: "6.7K", following: true, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-    { username: "디저트퀸", id: "@dessert_queen", count: "9.1K", following: false, img: "https://mblogthumb-phinf.pstatic.net/MjAyMDAyMTBfODAg/MDAxNTgxMzA0MTE3ODMy.ACRLtB9v5NH-I2qjWrwiXLb7TeUiG442cJmcdzVum7cg.eTLpNg_n0rAS5sWOsofRrvBy0qZk_QcWSfUiIagTfd8g.JPEG.lattepain/1581304118739.jpg?type=w800" },
-  ];
-
-  // 현재 탭에 따라 보여줄 목록 선택
-  const userList = activeTab === "followers" ? followers : followings;
-
   return (
-    <div className="follow-modal-overlay" onClick={onClose}>
+    <div className="follow-modal-overlay">
       <div className="follow-modal" onClick={(e) => e.stopPropagation()}>
         <FollowHeader activeTab={activeTab} setActiveTab={setActiveTab} onClose={onClose} />
         <div className="follow-list">
           {userList.map((f, index) => (
             <FollowCard
-              key={index}
-              username={f.username}
-              userId={f.id}
-              followerCount={f.count}
-              isFollowing={f.following}
-              profileImg={f.img}
+              key={f.followId}
+              followId={f.followId}
+              username={f.nickname}
+              userId={f.userId}
+              email={f.localEmail ? f.localEmail : f.kakaoEmail}
+              followerCount={f.followerCount}
+              isFollowed={f.isFollowed}
+              profileImg={f.profileImgPath}
             />
           ))}
         </div>


### PR DESCRIPTION
- 팔로워/팔로잉 목록 조회 
- 팔로우/언팔로우 처리 구현

[ 추가 구현 예정 ]
1. 팔로워 목록 클릭시 사용자 프로필 이동
2. 사용자 이미지 불러오기
3. 팔로워 모달 닫았을 때, 메인화면 팔로워/팔로잉 수 갱신