### PR TITLE
Feature/setting

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/JWTUtil.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/auth/jwt/JWTUtil.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.Date;
 
 @Component

--- a/backend/sloweat/src/main/java/com/sloweat/domain/user/controller/ProfileController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/user/controller/ProfileController.java
@@ -15,13 +15,15 @@ import org.springframework.web.bind.annotation.*;
 public class ProfileController {
 
     private final ProfileService profileService;
-
+    
+    //프로필 불러오기
     @GetMapping("/users/me/profile")
     public ResponseEntity<MyProfileResponseDTO> getMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
        MyProfileResponseDTO dto = profileService.getMyProfile(customUserDetails);
        return ResponseEntity.ok(dto);
     }
-
+    
+    //프로필 수정
     @PatchMapping("/users/me/profile")
     public ResponseEntity<Void> editMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                            @RequestBody MyProfileRequestDTO myProfileRequestDTO) {

--- a/backend/sloweat/src/main/java/com/sloweat/domain/user/controller/ProfileController.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/user/controller/ProfileController.java
@@ -1,14 +1,13 @@
 package com.sloweat.domain.user.controller;
 
 import com.sloweat.domain.auth.dto.CustomUserDetails;
+import com.sloweat.domain.user.dto.MyProfileRequestDTO;
 import com.sloweat.domain.user.dto.MyProfileResponseDTO;
 import com.sloweat.domain.user.service.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +20,13 @@ public class ProfileController {
     public ResponseEntity<MyProfileResponseDTO> getMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
        MyProfileResponseDTO dto = profileService.getMyProfile(customUserDetails);
        return ResponseEntity.ok(dto);
+    }
+
+    @PatchMapping("/users/me/profile")
+    public ResponseEntity<Void> editMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                           @RequestBody MyProfileRequestDTO myProfileRequestDTO) {
+        profileService.editMyProfile(customUserDetails,myProfileRequestDTO);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/backend/sloweat/src/main/java/com/sloweat/domain/user/dto/MyProfileRequestDTO.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/user/dto/MyProfileRequestDTO.java
@@ -1,0 +1,14 @@
+package com.sloweat.domain.user.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyProfileRequestDTO {
+    private String nickname;
+    private String profileImgPath;
+    private String introduce;
+}

--- a/backend/sloweat/src/main/java/com/sloweat/domain/user/service/ProfileService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/user/service/ProfileService.java
@@ -9,7 +9,6 @@ import com.sloweat.domain.user.dto.MyProfileResponseDTO;
 import com.sloweat.domain.user.entity.User;
 import com.sloweat.domain.user.repository.UserRepository;
 import lombok.*;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;

--- a/backend/sloweat/src/main/java/com/sloweat/domain/user/service/ProfileService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/user/service/ProfileService.java
@@ -5,6 +5,7 @@ import com.sloweat.domain.follow.repository.FollowRepository;
 import com.sloweat.domain.recipe.repository.RecipeRepository;
 import com.sloweat.domain.subscription.entity.Subscription;
 import com.sloweat.domain.subscription.repository.SubscriptionRepository;
+import com.sloweat.domain.user.dto.MyProfileRequestDTO;
 import com.sloweat.domain.user.dto.MyProfileResponseDTO;
 import com.sloweat.domain.user.entity.User;
 import com.sloweat.domain.user.repository.UserRepository;
@@ -27,9 +28,7 @@ public class ProfileService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
 
-        String id =  user.getLocalEmail() != null
-                ? user.getLocalEmail()
-                : user.getKakaoEmail().split("@")[0];
+        String id =  user.getLocalEmail();
 
         long follower_cnt = followRepository.countByFollowing(user);
         long following_cnt = followRepository.countByFollower(user);
@@ -46,5 +45,17 @@ public class ProfileService {
                 .followingCnt(following_cnt)
                 .postCnt(post_cnt)
                 .build();
+    }
+
+    public void editMyProfile(CustomUserDetails customUserDetails, MyProfileRequestDTO myProfileRequestDTO) {
+        Integer userId = customUserDetails.getUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
+
+        user.setNickname(myProfileRequestDTO.getNickname());
+        user.setIntroduce(myProfileRequestDTO.getIntroduce());
+        user.setProfileImgPath(myProfileRequestDTO.getProfileImgPath());
+
+        userRepository.save(user);
     }
 }

--- a/frontend/src/api/user/profile.js
+++ b/frontend/src/api/user/profile.js
@@ -2,7 +2,13 @@
 import axiosInstance from "../axiosInstance";
 
 //내 프로필 가져오기
-//api/users/me/profile
+//GET api/users/me/profile
 export const getMyProfile = async () => {
   return axiosInstance.get('api/users/me/profile');
 };
+
+//개인정보 변경
+//POST api/users/me/profile
+export const editMyProfile = async (requestDTO) => {
+  return axiosInstance.patch('api/users/me/profile',requestDTO)
+}

--- a/frontend/src/components/user/PasswordChangeModal.jsx
+++ b/frontend/src/components/user/PasswordChangeModal.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "../../styles/user/PasswordChangeModal.css";
 
 const PasswordChangeModal = () => {

--- a/frontend/src/components/user/PersonalInfoEdit.jsx
+++ b/frontend/src/components/user/PersonalInfoEdit.jsx
@@ -1,9 +1,10 @@
 import {useState, useEffect} from 'react';
 import ProfilePictureUploader from './ProfilePictureUploader';
+import PasswordChangeModal from './PasswordChangeModal';
 import { checkNickname } from '../../api/user/auth';
 import { editMyProfile } from '../../api/user/profile';
 
-const PersonalInfoEdit = ({profile : initialProfile, profileUpdated}) => {
+const PersonalInfoEdit = ({profile : initialProfile}) => {
 
   const [profile, setProfile] = useState({});
   const [errors, setErrors] = useState({});
@@ -67,7 +68,8 @@ const PersonalInfoEdit = ({profile : initialProfile, profileUpdated}) => {
 
       await editMyProfile(requestDTO);
       alert('수정되었습니다');
-      profileUpdated();
+      window.location.reload();
+
 
     }catch(err){
       console.error('프로필 수정 실패',err);

--- a/frontend/src/components/user/PersonalInfoEdit.jsx
+++ b/frontend/src/components/user/PersonalInfoEdit.jsx
@@ -1,18 +1,78 @@
-// PersonalInfoEdit.jsx
-import React, { useState } from 'react';
+import {useState, useEffect} from 'react';
 import ProfilePictureUploader from './ProfilePictureUploader';
+import { checkNickname } from '../../api/user/auth';
+import { editMyProfile } from '../../api/user/profile';
 
-const PersonalInfoEdit = () => {
-  const [userId, setUserId] = useState('kimcook');
-  const [nickname, setNickname] = useState('');
-  const [profileIntro, setProfileIntro] = useState('');
+const PersonalInfoEdit = ({profile : initialProfile, profileUpdated}) => {
 
-  const handleDuplicateCheck = () => {
-    console.log('중복 확인 버튼 클릭됨');
+  const [profile, setProfile] = useState({});
+  const [errors, setErrors] = useState({});
+  const [isFormValid, setIsFormValid] = useState(false);
+  const [isNicknameChecked, setIsNicknameChecked] = useState(false);
+  const isSameNickname = profile.nickname === initialProfile?.nickname;
+  const isSameIntroduce = profile.introduce === initialProfile?.introduce;
+  const isChanged = !isSameNickname || !isSameIntroduce;
+
+  //proile 초기 렌더링
+  useEffect(() => {
+    if (initialProfile) {
+      setProfile(initialProfile);
+      setErrors({});
+      setIsFormValid(false); 
+      setIsNicknameChecked(false);
+    }
+    }, [initialProfile]);
+
+  //개인정보 유효성 검사
+  useEffect(() => {
+    const newErrors = {};
+
+    if (!/^.{2,15}$/.test(profile.nickname)) {
+      newErrors.nickname = '닉네임은 2~15자 이내여야합니다.';
+    }
+
+    if (profile.introduce && profile.introduce.length > 100) {
+      newErrors.introduce = '프로필 소개는 100자 이내여야합니다.';
+    }
+
+    setErrors(newErrors);
+    setIsFormValid(Object.keys(newErrors).length === 0);
+  }, [profile.nickname, profile.introduce]);
+
+  //닉네임 중복 확인
+  const handleDuplicateCheck = async () => {
+  try {
+    const res = await checkNickname(profile.nickname);
+    if (res.data === true) {
+      setErrors(prev => ({ ...prev, nickname: '이미 사용 중인 닉네임입니다.' }));
+      setIsNicknameChecked(false);
+    } else{
+      alert('사용 가능한 닉네임입니다!');
+      setIsNicknameChecked(true);
+    }
+  } catch (err) {
+    alert('닉네임 중복 확인 오류 발생');
+    setIsNicknameChecked(false);
+  }
   };
 
-  const handleSave = () => {
-    console.log('저장하기 버튼 클릭됨');
+  //수정사항 저장
+  const handleSave = async () => {
+    try{
+      const requestDTO = {
+        nickname : profile.nickname,
+        introduce : profile.introduce,
+        profileImgPath : profile.profileImgPath
+      };
+
+      await editMyProfile(requestDTO);
+      alert('수정되었습니다');
+      profileUpdated();
+
+    }catch(err){
+      console.error('프로필 수정 실패',err);
+      alert('프로필 수정 중 오류가 발생했습니다');
+    }
   };
 
   const handlePasswordChange = () => {
@@ -30,9 +90,9 @@ const PersonalInfoEdit = () => {
         <input
           type="text"
           className="settings-input-field"
-          value={userId}
-          onChange={(e) => setUserId(e.target.value)}
-          placeholder="kimcook"
+          style={{pointerEvents:"none", backgroundColor:"#f3f3f3ff",color:"gray"}}
+          value={profile?.id}
+          readOnly
         />
       </div>
 
@@ -42,16 +102,21 @@ const PersonalInfoEdit = () => {
           <input
             type="text"
             className="settings-nickname-input"
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
+            value={profile?.nickname || ''}
+            onChange={(e) => {
+              setProfile(prev => ({ ...prev, nickname: e.target.value }));
+              setIsNicknameChecked(false); 
+            }}
             placeholder="닉네임을 입력하세요"
           />
           <button
             className="settings-duplicate-check-button"
             onClick={handleDuplicateCheck}
+            disabled={isSameNickname}
           >
             중복확인
           </button>
+          {errors.nickname && <p className="form-error">{errors.nickname}</p>}
         </div>
       </div>
 
@@ -59,15 +124,20 @@ const PersonalInfoEdit = () => {
         <div className="settings-input-label">프로필 소개</div>
         <textarea
           className="settings-textarea-field"
-          value={profileIntro}
-          onChange={(e) => setProfileIntro(e.target.value)}
-          placeholder="자신을 소개해보세요"
+          value={profile?.introduce || ''}
+          onChange={(e) => setProfile(prev => ({
+                            ...prev,
+                            introduce: e.target.value
+                            }))}
+          placeholder="프로필 소개를 입력하세요"
         />
+        {errors.introduce && <p className="form-error">{errors.introduce}</p>}
       </div>
 
       <div className="settings-action-buttons">
         <button
           className="settings-save-button"
+          disabled={!isFormValid || (!isSameNickname && !isNicknameChecked) || !isChanged}
           onClick={handleSave}
         >
           저장하기

--- a/frontend/src/components/user/ProfileCard.jsx
+++ b/frontend/src/components/user/ProfileCard.jsx
@@ -1,25 +1,9 @@
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../../styles/user/ProfileCard.css';
-import { getMyProfile } from '../../api/user/profile';
 import {logout} from '../../api/user/auth';
 
-export default function ProfileCard() {
+export default function ProfileCard({ profile }) {
   const navigate = useNavigate();
-
-  const [profile,setProfile] = useState(null);
-
-  useEffect(()=>{
-    const profile = async()=>{
-      try{
-        const res = await getMyProfile();
-        setProfile(res.data);
-      }catch(err){
-        console.error('프로필 불러오기 실패',err);
-      }
-    };
-    profile();
-  },[]);
 
   const handleLogout = async (e) => {
     e.stopPropagation();
@@ -32,7 +16,6 @@ export default function ProfileCard() {
       alert('로그아웃 되었습니다.');
 
       localStorage.removeItem('accessToken');
-      setProfile(null);
 
       window.location.href = '/login';
     } catch (err) {

--- a/frontend/src/components/user/ProfileCard.jsx
+++ b/frontend/src/components/user/ProfileCard.jsx
@@ -19,7 +19,7 @@ export default function ProfileCard() {
       }
     };
     profile();
-  },[]);
+  },[profile]);
 
   const handleLogout = async (e) => {
     e.stopPropagation();

--- a/frontend/src/components/user/ProfileCard.jsx
+++ b/frontend/src/components/user/ProfileCard.jsx
@@ -19,7 +19,7 @@ export default function ProfileCard() {
       }
     };
     profile();
-  },[profile]);
+  },[]);
 
   const handleLogout = async (e) => {
     e.stopPropagation();

--- a/frontend/src/layouts/user/Tab.jsx
+++ b/frontend/src/layouts/user/Tab.jsx
@@ -1,13 +1,30 @@
 import SubscribeBanner from "../../components/user/SubscribeBanner.jsx";
 import { Link } from "react-router-dom"; 
+import {useEffect, useState} from "react";
 import SideBar from "../../components/user/SideBar.jsx";
 import ProfileCard from "../../components/user/ProfileCard.jsx";
+import { getMyProfile } from '../../api/user/profile';
 import './MainLayout.css';
 import logo from '../../img/logo.svg';
 
 
 //좌측 탭
 export default function Tab() {
+  const [profile,setProfile] = useState(null);
+
+  //프로필 불러오기
+  useEffect(()=>{
+      const profile = async()=>{
+        try{
+          const res = await getMyProfile();
+          setProfile(res.data);
+        }catch(err){
+          console.error('프로필 불러오기 실패',err);
+        }
+      };
+      profile();
+    },[]);
+  
   return (
     <div className="main-layout-tab">
             <div className="tab-logo">
@@ -20,7 +37,7 @@ export default function Tab() {
             {/* 탭 바 */}
             <SideBar></SideBar>
             {/* 프로필 카드*/}
-            <ProfileCard></ProfileCard>
+            <ProfileCard profile={profile}></ProfileCard>
     </div>
   );
 }

--- a/frontend/src/pages/user/Settings.css
+++ b/frontend/src/pages/user/Settings.css
@@ -141,6 +141,13 @@
   margin-bottom: 8px;
 }
 
+.recipe-form-group input:focus,
+.recipe-textarea:focus {
+  outline: none;
+  border-color: #10b981;
+  background-color: #ffffff;
+}
+
 .settings-input-field {
   width: 298px;
   height: 42px;
@@ -178,7 +185,7 @@
 }
 
 .settings-duplicate-check-button {
-  background-color: rgba(16, 185, 129, 0.5);
+  background-color: #10b981;
   color: #ffffff;
   border: none;
   border-radius: 8px;
@@ -192,6 +199,12 @@
   white-space: nowrap;
 }
 
+.settings-duplicate-check-button:disabled {
+  background-color: #ccc;
+  color: #999;
+  cursor: not-allowed;
+}
+
 .settings-textarea-field {
   width: 613px;
   height: 40px;
@@ -201,8 +214,9 @@
   padding: 13px 18px;
   font-size: 14px;
   color: #1a1a1a;
-  resize: vertical;
-  min-height: 48px;
+  resize: none;
+  min-height: 70px;
+  font-family : Inter;
 }
 
 .settings-textarea-field::placeholder {
@@ -228,6 +242,12 @@
   cursor: pointer;
   width: 100px;
   text-align: center;
+}
+
+.settings-save-button:disabled {
+  background-color: #ccc;
+  color: #999;
+  cursor: not-allowed;
 }
 
 .settings-password-change-button {

--- a/frontend/src/pages/user/Settings.jsx
+++ b/frontend/src/pages/user/Settings.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './Settings.css';
 import SettingNavigation from '../../components/user/SettingNavigation';
 import PersonalInfoEdit from '../../components/user/PersonalInfoEdit';
@@ -6,28 +6,46 @@ import AccountWithdrawal from '../../components/user/AccountWithdrawal';
 import ProfileSubscriptionGuest from '../../components/user/ProfileSubscriptionGuest';
 import ProfileSubscriptionMember from '../../components/user/ProfileSubscriptionMember';
 
-const Settings = () => {
-  const [activeTab, setActiveTab] = useState('account');
+import {getMyProfile} from '../../api/user/profile';
 
-  // 사용자 구독 상태 - 실제로는 API나 Context에서 가져와야 함
-  // 예시: const { isSubscribed } = useAuth(); 또는 useSubscription();
-  const [isSubscribed, setIsSubscribed] = useState(true); // 임시로 state 사용
+const Settings = () => {
+  //계정 설정, 구독 관리 탭
+  const [activeTab, setActiveTab] = useState('account');
+  const [profile, setProfile] = useState(null);
+
+  //사용자 profile 반환
+  const fetchProfile = async () => {
+    try {
+      const res = await getMyProfile();
+      setProfile(res.data);
+    } catch (err) {
+      console.error('프로필 불러오기 실패', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchProfile();
+  }, []);
+
 
   const renderContent = () => {
     switch (activeTab) {
+      //계정 설정 탭
       case 'account':
         return (
           <div style={{ width: '675px' }}>
             {/* 개인정보 수정 */}
-            <PersonalInfoEdit />
+            <PersonalInfoEdit profile={profile} profileUpdated={fetchProfile}/>
 
             {/* 회원 탈퇴 */}
             <AccountWithdrawal />
           </div>
         );
-
+        
+      //구독 관리 탭
       case 'subscription':
-        return isSubscribed ? <ProfileSubscriptionMember /> : <ProfileSubscriptionGuest />;
+        //구독자,비구독자
+        return profile?.isSubscribed ? <ProfileSubscriptionMember /> : <ProfileSubscriptionGuest />;
 
       default:
         return (

--- a/frontend/src/pages/user/Settings.jsx
+++ b/frontend/src/pages/user/Settings.jsx
@@ -14,18 +14,17 @@ const Settings = () => {
   const [profile, setProfile] = useState(null);
 
   //사용자 profile 반환
-  const fetchProfile = async () => {
-    try {
-      const res = await getMyProfile();
-      setProfile(res.data);
-    } catch (err) {
-      console.error('프로필 불러오기 실패', err);
-    }
-  };
-
-  useEffect(() => {
-    fetchProfile();
-  }, []);
+    useEffect(()=>{
+      const profile = async()=>{
+        try{
+          const res = await getMyProfile();
+          setProfile(res.data);
+        }catch(err){
+          console.error('프로필 불러오기 실패',err);
+        }
+      };
+      profile();
+    },[]);
 
 
   const renderContent = () => {
@@ -35,7 +34,7 @@ const Settings = () => {
         return (
           <div style={{ width: '675px' }}>
             {/* 개인정보 수정 */}
-            <PersonalInfoEdit profile={profile} profileUpdated={fetchProfile}/>
+            <PersonalInfoEdit profile={profile}/>
 
             {/* 회원 탈퇴 */}
             <AccountWithdrawal />

--- a/frontend/src/styles/user/Profile.css
+++ b/frontend/src/styles/user/Profile.css
@@ -61,9 +61,15 @@
   line-height: 18px;
 }
 
-.mypage-profile-username,
+.mypage-profile-username{
+  font-size: 15px;
+  line-height: 22.5px;
+  font-weight: 400;
+}
+
 .mypage-profile-description {
-  margin: 0;
+  width : 520px;
+  margin-top : 8px;
   font-size: 15px;
   line-height: 22.5px;
   font-weight: 400;


### PR DESCRIPTION
## 요약
### 설정>계정 설정 탭 개인정보 수정 구현
<img width="1292" height="916" alt="image" src="https://github.com/user-attachments/assets/ff1c54da-2c29-4f8c-bdef-611663bec8b3" />

- 아이디는 변경 할 수 없음
- 닉네임 중복체크/유효성 검사
- 프로필 소개 유효성 검사
- 기존 닉네임/프로필과 변동 없을 시 저장하기 버튼 비활성화
- 저장 이후 새로고침으로 탭 부분 프로필 즉시 update

### Todo
- 이미지 연동
- 비밀번호 변경 로직 추가