### PR TITLE
구독 취소시 만료 전까지 구독 내역 탭 유지

### DIFF
--- a/backend/sloweat/src/main/java/com/sloweat/domain/subscription/repository/SubscriptionRepository.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/subscription/repository/SubscriptionRepository.java
@@ -11,9 +11,11 @@ import java.util.Optional;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Integer> {
 
-    Optional<Subscription> findByUserUserIdAndStatus(Integer userId, Subscription.Status status);
-
+    //Optional<Subscription> findByUserUserIdAndStatus(Integer userId, Subscription.Status status);
+    Optional<Subscription> findByUserUserIdAndStatusIn(Integer userId, List<Subscription.Status> statuses);
     boolean existsByUserUserIdAndStatus(Integer userId, Subscription.Status status);
+
+    boolean existsByUserUserIdAndStatusIn(Integer userId, List<Subscription.Status> statuses);
 
     Optional<Subscription> findByCustomerUid(String customerUid);
 

--- a/backend/sloweat/src/main/java/com/sloweat/domain/subscription/service/SubscriptionService.java
+++ b/backend/sloweat/src/main/java/com/sloweat/domain/subscription/service/SubscriptionService.java
@@ -42,9 +42,11 @@ public class SubscriptionService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        // 기존 활성 구독 확인
-        Optional<Subscription> existingSubscription = subscriptionRepository
-                .findByUserUserIdAndStatus(userId, Subscription.Status.ACTIVE);
+        // 기존 구독 확인
+        Optional<Subscription> existingSubscription = subscriptionRepository.findByUserUserIdAndStatusIn(
+                userId,
+                List.of(Subscription.Status.ACTIVE, Subscription.Status.CANCEL)
+        );
 
         if (existingSubscription.isPresent()) {
             throw new RuntimeException("User already has an active subscription");
@@ -90,8 +92,9 @@ public class SubscriptionService {
      * 구독 상세 조회
      */
     public SubscriptionResponse getSubscription(CustomUserDetails customUserDetails) {
-        Subscription subscription = subscriptionRepository
-                .findByUserUserIdAndStatus(customUserDetails.getUserId(), Subscription.Status.ACTIVE)
+        Subscription subscription = subscriptionRepository.findByUserUserIdAndStatusIn(
+                customUserDetails.getUserId(),
+                List.of(Subscription.Status.ACTIVE, Subscription.Status.CANCEL))
                 .orElseThrow(() -> new RuntimeException("Subscription not found"));
         return SubscriptionResponse.from(subscription);
     }
@@ -167,7 +170,10 @@ public class SubscriptionService {
                 .userId(userId)
                 .nickname(user.getNickname())
                 .id(id)
-                .subscribed(subscriptionRepository.existsByUserUserIdAndStatus(userId, Subscription.Status.ACTIVE))
+                .subscribed(subscriptionRepository.existsByUserUserIdAndStatusIn(
+                        userId,
+                        List.of(Subscription.Status.ACTIVE, Subscription.Status.CANCEL)
+                ))
                 .build();
     }
 

--- a/frontend/src/components/user/ProfileSubscriptionMember.jsx
+++ b/frontend/src/components/user/ProfileSubscriptionMember.jsx
@@ -64,10 +64,7 @@ const ProfileSubscriptionMember = ({ userId }) => {
     try {
       await cancelSubscription();
       alert('구독이 취소되었습니다.');
-      //await refreshSubscription();
-      setTimeout(() => {
-              window.location.reload();
-            }, 1000);
+      await refreshSubscription();
     } catch (err) {
       console.error('구독 취소 실패:', err);
       alert('구독 취소에 실패했습니다: ' + err.message);


### PR DESCRIPTION
기존 활성 구독만 조회에서 활성 및 취소 구독도 조회에 포함하여 구독 취소하더라도 만료전 까지 구독 내역 탭 유지 하게 했습니다 